### PR TITLE
Add Ukrainian language option

### DIFF
--- a/docs/i18n.md
+++ b/docs/i18n.md
@@ -1,10 +1,10 @@
 # Internationalization (i18n)
 
-The application supports Vietnamese and English UI strings. Translation files are located in `lang/vi.php` and `lang/en.php` and return associative arrays of key/value pairs.
+The application supports Vietnamese, English and Ukrainian UI strings. Translation files are located in `lang/vi.php`, `lang/en.php` and `lang/uk.php` and return associative arrays of key/value pairs.
 
 A small loader `i18n.php` checks `$_GET['lang']` or `$_SESSION['lang']` to decide which file to include and exposes a helper function `__($key)` for fetching strings.
 
-To switch language, use the links displayed in the header (`?lang=vi` or `?lang=en`). The selected language is stored in the session.
+To switch language, use the links displayed in the header (`?lang=vi`, `?lang=en` or `?lang=uk`). The selected language is stored in the session.
 
 Example usage:
 

--- a/header.php
+++ b/header.php
@@ -52,16 +52,20 @@ require_once __DIR__ . '/i18n.php';
             </a>
           <?php endif; ?>
           <span class="hidden sm:block">
-            <a href="?lang=vi" class="text-sm <?= ($_SESSION['lang'] ?? 'vi') === 'vi' ? 'font-bold' : '' ?>"><?= __('language_vi') ?></a>
+            <a href="?lang=vi" class="text-sm <?= ($_SESSION['lang'] ?? 'vi') === 'vi' ? 'font-bold' : '' ?>" aria-label="<?= __('language_vi') ?>">🇻🇳</a>
             |
-            <a href="?lang=en" class="text-sm <?= ($_SESSION['lang'] ?? 'vi') === 'en' ? 'font-bold' : '' ?>"><?= __('language_en') ?></a>
+            <a href="?lang=en" class="text-sm <?= ($_SESSION['lang'] ?? 'vi') === 'en' ? 'font-bold' : '' ?>" aria-label="<?= __('language_en') ?>">🇬🇧</a>
+            |
+            <a href="?lang=uk" class="text-sm <?= ($_SESSION['lang'] ?? 'vi') === 'uk' ? 'font-bold' : '' ?>" aria-label="<?= __('language_uk') ?>">🇺🇦</a>
           </span>
         </div>
       </div>
       <div class="block sm:hidden text-center mt-1">
-        <a href="?lang=vi" class="text-sm <?= ($_SESSION['lang'] ?? 'vi') === 'vi' ? 'font-bold' : '' ?>"><?= __('language_vi') ?></a>
+        <a href="?lang=vi" class="text-sm <?= ($_SESSION['lang'] ?? 'vi') === 'vi' ? 'font-bold' : '' ?>" aria-label="<?= __('language_vi') ?>">🇻🇳</a>
         |
-        <a href="?lang=en" class="text-sm <?= ($_SESSION['lang'] ?? 'vi') === 'en' ? 'font-bold' : '' ?>"><?= __('language_en') ?></a>
+        <a href="?lang=en" class="text-sm <?= ($_SESSION['lang'] ?? 'vi') === 'en' ? 'font-bold' : '' ?>" aria-label="<?= __('language_en') ?>">🇬🇧</a>
+        |
+        <a href="?lang=uk" class="text-sm <?= ($_SESSION['lang'] ?? 'vi') === 'uk' ? 'font-bold' : '' ?>" aria-label="<?= __('language_uk') ?>">🇺🇦</a>
       </div>
     </div>
   </header>

--- a/home.php
+++ b/home.php
@@ -134,16 +134,20 @@ require 'config.php';
                     <?= __('login_button') ?>
                 </a>
                 <span class="hidden sm:block">
-                  <a href="?lang=vi" class="text-sm <?= ($_SESSION['lang'] ?? 'vi') === 'vi' ? 'font-bold' : '' ?>"><?= __('language_vi') ?></a>
+                  <a href="?lang=vi" class="text-sm <?= ($_SESSION['lang'] ?? 'vi') === 'vi' ? 'font-bold' : '' ?>" aria-label="<?= __('language_vi') ?>">🇻🇳</a>
                   |
-                  <a href="?lang=en" class="text-sm <?= ($_SESSION['lang'] ?? 'vi') === 'en' ? 'font-bold' : '' ?>"><?= __('language_en') ?></a>
+                  <a href="?lang=en" class="text-sm <?= ($_SESSION['lang'] ?? 'vi') === 'en' ? 'font-bold' : '' ?>" aria-label="<?= __('language_en') ?>">🇬🇧</a>
+                  |
+                  <a href="?lang=uk" class="text-sm <?= ($_SESSION['lang'] ?? 'vi') === 'uk' ? 'font-bold' : '' ?>" aria-label="<?= __('language_uk') ?>">🇺🇦</a>
                 </span>
             </div>
         </div>
         <div class="block sm:hidden text-center mt-1">
-            <a href="?lang=vi" class="text-sm <?= ($_SESSION['lang'] ?? 'vi') === 'vi' ? 'font-bold' : '' ?>"><?= __('language_vi') ?></a>
+            <a href="?lang=vi" class="text-sm <?= ($_SESSION['lang'] ?? 'vi') === 'vi' ? 'font-bold' : '' ?>" aria-label="<?= __('language_vi') ?>">🇻🇳</a>
             |
-            <a href="?lang=en" class="text-sm <?= ($_SESSION['lang'] ?? 'vi') === 'en' ? 'font-bold' : '' ?>"><?= __('language_en') ?></a>
+            <a href="?lang=en" class="text-sm <?= ($_SESSION['lang'] ?? 'vi') === 'en' ? 'font-bold' : '' ?>" aria-label="<?= __('language_en') ?>">🇬🇧</a>
+            |
+            <a href="?lang=uk" class="text-sm <?= ($_SESSION['lang'] ?? 'vi') === 'uk' ? 'font-bold' : '' ?>" aria-label="<?= __('language_uk') ?>">🇺🇦</a>
         </div>
     </div>
   </header>

--- a/i18n.php
+++ b/i18n.php
@@ -6,7 +6,12 @@ if (session_status() === PHP_SESSION_NONE) {
 function load_lang(): void {
     $lang = $_SESSION['lang'] ?? 'vi';
     if (isset($_GET['lang'])) {
-        $lang = $_GET['lang'] === 'en' ? 'en' : 'vi';
+        $chosen = $_GET['lang'];
+        if (in_array($chosen, ['vi', 'en', 'uk'], true)) {
+            $lang = $chosen;
+        } else {
+            $lang = 'vi';
+        }
         $_SESSION['lang'] = $lang;
     }
     $file = __DIR__ . "/lang/$lang.php";

--- a/lang/en.php
+++ b/lang/en.php
@@ -53,6 +53,7 @@ return [
     'create_student' => 'Create student',
     'language_vi' => 'Vietnamese',
     'language_en' => 'English',
+    'language_uk' => 'Ukrainian',
     'out_of_sessions' => 'You have no sessions left!',
     'contact_admin' => 'Please contact admin to add more sessions.',
     'renew_zalo1' => 'Renew via Zalo Nguyễn Hữu Tín 0839269501',

--- a/lang/vi.php
+++ b/lang/vi.php
@@ -53,6 +53,7 @@ return [
     'create_student' => 'Tạo học viên',
     'language_vi' => 'Tiếng Việt',
     'language_en' => 'English',
+    'language_uk' => 'Tiếng Ukraine',
     'out_of_sessions' => 'Bạn đã hết buổi học!',
     'contact_admin' => 'Vui lòng liên hệ admin để được cộng thêm buổi nhé.',
     'renew_zalo1' => 'Đăng ký gia hạn qua Zalo Nguyễn Hữu Tín 0839269501',


### PR DESCRIPTION
## Summary
- allow `uk` value in i18n loader
- include Ukrainian language names in English and Vietnamese language files
- document Ukrainian translation file
- show flag icons in the header and on the home page

## Testing
- `php -l i18n.php`
- `php -l header.php`
- `php -l home.php`
- `php -l lang/en.php`
- `php -l lang/vi.php`
- `phpunit` *(fails: command not found)*
- `composer install` *(fails: blocked from downloading)*

------
https://chatgpt.com/codex/tasks/task_b_68809c1169c48326b16c359ce9dd815a