### PR TITLE
Enhance chatbot UI

### DIFF
--- a/chatbot.php
+++ b/chatbot.php
@@ -3,21 +3,30 @@ require 'config.php';
 $pageTitle = __('chatbot');
 include 'header.php';
 ?>
-<main class="max-w-2xl mx-auto px-4 py-8">
-  <h1 class="text-2xl font-semibold mb-4"><?= __('chatbot') ?></h1>
-  <div id="chat-log" class="bg-white border border-gray-300 rounded-lg p-4 h-96 overflow-y-auto space-y-2"></div>
-  <form id="chat-form" class="mt-4 flex">
-    <input id="chat-input" type="text" class="flex-grow border border-gray-300 rounded-l-lg p-2 focus:outline-none" placeholder="<?= __('chatbot_placeholder') ?>" />
-    <button type="submit" class="px-4 py-2 bg-[#9dcfc3] text-[#285F57] rounded-r-lg hover:bg-[#76a89e]">
-      <?= __('chatbot_send') ?>
-    </button>
-  </form>
+<main class="flex justify-center px-4 py-8">
+  <div class="w-full max-w-lg bg-white rounded-2xl shadow-md p-4 flex flex-col">
+    <h1 class="text-2xl font-semibold mb-4"><?= __('chatbot') ?></h1>
+    <div id="chat-log" class="flex-1 overflow-y-auto space-y-3 mb-4 h-96"></div>
+    <form id="chat-form" class="flex gap-2">
+      <input id="chat-input" type="text" class="flex-grow border border-gray-300 rounded-full px-3 py-2 focus:outline-none" placeholder="<?= __('chatbot_placeholder') ?>" />
+      <button type="submit" class="px-4 py-2 bg-[#9dcfc3] text-[#285F57] rounded-full hover:bg-[#76a89e]">
+        <?= __('chatbot_send') ?>
+      </button>
+    </form>
+  </div>
 </main>
 <script>
 document.addEventListener('DOMContentLoaded', () => {
   const form = document.getElementById('chat-form');
   const input = document.getElementById('chat-input');
   const log   = document.getElementById('chat-log');
+
+  input.addEventListener('keydown', e => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      form.requestSubmit();
+    }
+  });
 
   form.addEventListener('submit', async (e) => {
     e.preventDefault();
@@ -26,15 +35,16 @@ document.addEventListener('DOMContentLoaded', () => {
     input.value = '';
 
     const userWrap = document.createElement('div');
-    userWrap.className = 'flex justify-end mb-2';
+    userWrap.className = 'flex justify-end';
     const userBubble = document.createElement('div');
-    userBubble.className = 'bg-blue-500 text-white px-4 py-2 rounded-lg max-w-xs break-words whitespace-pre-wrap';
+    userBubble.className = 'bg-blue-500 text-white px-4 py-2 rounded-2xl max-w-xs break-words whitespace-pre-wrap';
     userBubble.textContent = text;
     userWrap.appendChild(userBubble);
     log.appendChild(userWrap);
+    log.scrollTop = log.scrollHeight;
 
     const indicator = document.createElement('div');
-    indicator.className = 'flex justify-start mb-2';
+    indicator.className = 'flex justify-start';
     indicator.innerHTML =
       `<div class="bg-gray-200 px-3 py-2 rounded-lg flex space-x-1">
          <span class="h-2 w-2 bg-gray-500 rounded-full animate-[wave_1.2s_infinite]"></span>
@@ -55,16 +65,16 @@ document.addEventListener('DOMContentLoaded', () => {
         const data = await res.json();
         const reply = data.reply || data.error || 'Error';
         const botWrap = document.createElement('div');
-        botWrap.className = 'flex justify-start mb-2';
+        botWrap.className = 'flex justify-start';
         const botBubble = document.createElement('div');
-        botBubble.className = 'bg-gray-200 px-4 py-2 rounded-lg max-w-xs break-words whitespace-pre-wrap';
-        botBubble.textContent = reply;
+        botBubble.className = 'bg-gray-100 text-gray-800 px-4 py-2 rounded-2xl max-w-xs break-words whitespace-pre-wrap';
+        botBubble.innerHTML = reply.replace(/\n/g, '<br>');
         botWrap.appendChild(botBubble);
         log.appendChild(botWrap);
         log.scrollTop = log.scrollHeight;
       } else {
         const errorWrap = document.createElement('div');
-        errorWrap.className = 'flex justify-start mb-2';
+        errorWrap.className = 'flex justify-start';
         errorWrap.innerHTML =
           '<div class="bg-gray-200 text-red-600 px-4 py-2 rounded-lg">Error</div>';
         log.appendChild(errorWrap);
@@ -73,7 +83,7 @@ document.addEventListener('DOMContentLoaded', () => {
     } catch (err) {
       indicator.remove();
       const errorWrap = document.createElement('div');
-      errorWrap.className = 'flex justify-start mb-2';
+      errorWrap.className = 'flex justify-start';
       errorWrap.innerHTML =
         '<div class="bg-gray-200 text-red-600 px-4 py-2 rounded-lg">Error</div>';
       log.appendChild(errorWrap);


### PR DESCRIPTION
## Summary
- restyle chat area as a centered card
- add Enter key listener and auto-scroll
- show user/assistant bubbles with improved colors
- render assistant replies as HTML

## Testing
- `php -l chatbot.php`
- `vendor/bin/phpunit tests` *(fails: file not found)*

------
https://chatgpt.com/codex/tasks/task_b_6881b895dc1c8326ba45302f27748f09