### PR TITLE
Update chatbot layout

### DIFF
--- a/chatbot.php
+++ b/chatbot.php
@@ -3,23 +3,28 @@ require 'config.php';
 $pageTitle = __('chatbot');
 include 'header.php';
 ?>
-<main class="flex justify-center px-4 py-8">
-  <div class="w-full max-w-lg bg-white rounded-2xl shadow-md p-4 flex flex-col">
-    <h1 class="text-2xl font-semibold mb-4"><?= __('chatbot') ?></h1>
-    <div id="chat-log" class="flex-1 overflow-y-auto space-y-3 mb-4 h-96"></div>
-    <form id="chat-form" class="flex gap-2">
-      <input id="chat-input" type="text" class="flex-grow border border-gray-300 rounded-full px-3 py-2 focus:outline-none" placeholder="<?= __('chatbot_placeholder') ?>" />
-      <button type="submit" class="px-4 py-2 bg-[#9dcfc3] text-[#285F57] rounded-full hover:bg-[#76a89e]">
-        <?= __('chatbot_send') ?>
-      </button>
-    </form>
+<main class="flex flex-col items-center min-h-screen px-4 pt-4 pb-24">
+  <h1 class="text-2xl font-semibold mb-4 w-full max-w-lg text-center">
+    <?= __('chatbot') ?>
+  </h1>
+  <div id="chat-log" class="w-full max-w-lg flex-1 overflow-y-auto space-y-3 pb-4">
+    <div id="greeting" class="text-center text-gray-500 bg-white border border-gray-200 rounded-lg p-4">
+      NamaHealing Bot - Tư vấn lớp thiền chữ đựa
+    </div>
   </div>
+  <form id="chat-form" class="fixed bottom-0 left-1/2 -translate-x-1/2 w-full max-w-lg flex gap-2 px-4 py-3 bg-white border-t border-gray-200">
+    <input id="chat-input" type="text" class="flex-grow border border-gray-300 rounded-full px-3 py-2 focus:outline-none" placeholder="<?= __('chatbot_placeholder') ?>" />
+    <button type="submit" class="px-4 py-2 bg-[#9dcfc3] text-[#285F57] rounded-full hover:bg-[#76a89e]">
+      <?= __('chatbot_send') ?>
+    </button>
+  </form>
 </main>
 <script>
 document.addEventListener('DOMContentLoaded', () => {
   const form = document.getElementById('chat-form');
   const input = document.getElementById('chat-input');
   const log   = document.getElementById('chat-log');
+  const greeting = document.getElementById('greeting');
 
   input.addEventListener('keydown', e => {
     if (e.key === 'Enter') {
@@ -33,11 +38,12 @@ document.addEventListener('DOMContentLoaded', () => {
     const text = input.value.trim();
     if (!text) return;
     input.value = '';
+    if (greeting) greeting.remove();
 
     const userWrap = document.createElement('div');
     userWrap.className = 'flex justify-end';
     const userBubble = document.createElement('div');
-    userBubble.className = 'bg-blue-500 text-white px-4 py-2 rounded-2xl max-w-xs break-words whitespace-pre-wrap';
+    userBubble.className = 'bg-teal-600 text-white px-4 py-2 rounded-lg max-w-xs break-words whitespace-pre-wrap';
     userBubble.textContent = text;
     userWrap.appendChild(userBubble);
     log.appendChild(userWrap);
@@ -67,7 +73,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const botWrap = document.createElement('div');
         botWrap.className = 'flex justify-start';
         const botBubble = document.createElement('div');
-        botBubble.className = 'bg-gray-100 text-gray-800 px-4 py-2 rounded-2xl max-w-xs break-words whitespace-pre-wrap';
+        botBubble.className = 'bg-gray-100 text-gray-800 px-4 py-2 rounded-lg max-w-xs break-words whitespace-pre-wrap';
         botBubble.innerHTML = reply.replace(/\n/g, '<br>');
         botWrap.appendChild(botBubble);
         log.appendChild(botWrap);


### PR DESCRIPTION
## Summary
- revamp chatbot UI layout to mimic ChatGPT
- make input sticky at bottom and add greeting placeholder
- tweak bubble colors

## Testing
- `php -l chatbot.php`
- `vendor/bin/phpunit --configuration phpunit.xml` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_6881bcadd850832688d031170a9c20ad