### PR TITLE
Improve mobile layout and chatbot UX

### DIFF
--- a/chatbot.php
+++ b/chatbot.php
@@ -3,7 +3,7 @@ require 'config.php';
 $pageTitle = __('chatbot');
 include 'header.php';
 ?>
-<main class="flex flex-col items-center min-h-screen px-4 pt-4 pb-24">
+<main class="flex flex-col items-center min-h-screen px-4 pt-4 pb-40">
   <h1 class="text-2xl font-semibold mb-4 w-full max-w-lg text-center">
     <?= __('chatbot') ?>
   </h1>
@@ -12,19 +12,25 @@ include 'header.php';
       NamaHealing Bot - Tư vấn lớp thiền chữ đựa
     </div>
   </div>
-  <form id="chat-form" class="fixed bottom-0 left-1/2 -translate-x-1/2 w-full max-w-lg flex gap-2 px-4 py-3 bg-white border-t border-gray-200">
+  <form id="chat-form" class="fixed bottom-20 left-1/2 -translate-x-1/2 w-full max-w-lg flex gap-2 px-4 py-3 bg-white border-t border-gray-200">
     <input id="chat-input" type="text" class="flex-grow border border-gray-300 rounded-full px-3 py-2 focus:outline-none" placeholder="<?= __('chatbot_placeholder') ?>" />
     <button type="submit" class="px-4 py-2 bg-[#9dcfc3] text-[#285F57] rounded-full hover:bg-[#76a89e]">
       <?= __('chatbot_send') ?>
     </button>
   </form>
 </main>
+<script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
 <script>
 document.addEventListener('DOMContentLoaded', () => {
   const form = document.getElementById('chat-form');
   const input = document.getElementById('chat-input');
   const log   = document.getElementById('chat-log');
   const greeting = document.getElementById('greeting');
+
+  const renderer = new marked.Renderer();
+  renderer.link = (href, title, text) =>
+    `<a href="${href}" target="_blank" rel="noopener noreferrer">${text}</a>`;
+  marked.setOptions({ breaks: true, mangle: false, headerIds: false, renderer });
 
   input.addEventListener('keydown', e => {
     if (e.key === 'Enter') {
@@ -70,13 +76,10 @@ document.addEventListener('DOMContentLoaded', () => {
       if (res.ok) {
         const data = await res.json();
         const reply = data.reply || data.error || 'Error';
-        const botWrap = document.createElement('div');
-        botWrap.className = 'flex justify-start';
-        const botBubble = document.createElement('div');
-        botBubble.className = 'bg-gray-100 text-gray-800 px-4 py-2 rounded-lg max-w-xs break-words whitespace-pre-wrap';
-        botBubble.innerHTML = reply.replace(/\n/g, '<br>');
-        botWrap.appendChild(botBubble);
-        log.appendChild(botWrap);
+        const botMsg = document.createElement('div');
+        botMsg.className = 'bg-gray-50 text-gray-800 px-4 py-2 rounded-md w-full whitespace-pre-wrap';
+        botMsg.innerHTML = marked.parse(reply);
+        log.appendChild(botMsg);
         log.scrollTop = log.scrollHeight;
       } else {
         const errorWrap = document.createElement('div');

--- a/home.php
+++ b/home.php
@@ -117,6 +117,15 @@ require 'config.php';
       font-size: 1.3rem;
       font-weight: 500;
     }
+
+    @media (max-width: 640px) {
+      #ukraine-class-btn {
+        position: fixed;
+        right: 24px;
+        bottom: 166px;
+        z-index: 9999;
+      }
+    }
   </style>
 </head>
 
@@ -179,7 +188,7 @@ require 'config.php';
           </ul>
         </nav>
         <div class="mt-4 text-center">
-          <a href="ukraine_meditation.php" class="px-4 py-2 rounded-full bg-emerald-600 text-white font-semibold hover:bg-emerald-700">Lớp Thiền Ukraine</a>
+          <a id="ukraine-class-btn" href="ukraine_meditation.php" class="px-4 py-2 rounded-full bg-emerald-600 text-white font-semibold hover:bg-emerald-700">Lớp Thiền Ukraine</a>
         </div>
     </div>
   </main>


### PR DESCRIPTION
## Summary
- float Ukraine class button above floating icons on mobile
- tidy chat view and switch assistant messages to Markdown
- bump chat input offset to avoid covering footer

## Testing
- `composer install` *(fails: CONNECT tunnel failed)*
- `./vendor/bin/phpunit tests` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_6881c1226c348326899804c60d6a3d08