### PR TITLE
Add docs section with admin management

### DIFF
--- a/data/docs.json
+++ b/data/docs.json
@@ -1,0 +1,5 @@
+{
+    "prayers": [],
+    "chanting": [],
+    "reference": []
+}

--- a/docs/chanting.php
+++ b/docs/chanting.php
@@ -1,9 +1,29 @@
 <?php
 $pageTitle = __('home_docs_chant');
+$file = __DIR__ . '/../data/docs.json';
+$docsData = [];
+if (file_exists($file)) {
+    $json = file_get_contents($file);
+    $docsData = json_decode($json, true);
+    if (!is_array($docsData)) $docsData = [];
+}
+$docs = $docsData['chanting'] ?? [];
 include '../header.php';
 ?>
 <main class="max-w-3xl mx-auto px-4 py-6">
   <h1 class="text-2xl font-semibold mb-4"><?= __('home_docs_chant') ?></h1>
-  <p>Coming soon...</p>
+  <?php if (empty($docs)): ?>
+    <p>Chưa có tài liệu.</p>
+  <?php else: ?>
+    <ul class="space-y-2">
+      <?php foreach ($docs as $d): ?>
+        <li>
+          <a href="<?= htmlspecialchars($d['link']) ?>" target="_blank" class="text-teal-600 hover:underline">
+            <?= htmlspecialchars($d['title']) ?>
+          </a>
+        </li>
+      <?php endforeach; ?>
+    </ul>
+  <?php endif; ?>
 </main>
 <?php include '../footer.php'; ?>

--- a/docs/prayers.php
+++ b/docs/prayers.php
@@ -1,9 +1,29 @@
 <?php
 $pageTitle = __('home_docs_prayer');
+$file = __DIR__ . '/../data/docs.json';
+$docsData = [];
+if (file_exists($file)) {
+    $json = file_get_contents($file);
+    $docsData = json_decode($json, true);
+    if (!is_array($docsData)) $docsData = [];
+}
+$docs = $docsData['prayers'] ?? [];
 include '../header.php';
 ?>
 <main class="max-w-3xl mx-auto px-4 py-6">
   <h1 class="text-2xl font-semibold mb-4"><?= __('home_docs_prayer') ?></h1>
-  <p>Coming soon...</p>
+  <?php if (empty($docs)): ?>
+    <p>Chưa có tài liệu.</p>
+  <?php else: ?>
+    <ul class="space-y-2">
+      <?php foreach ($docs as $d): ?>
+        <li>
+          <a href="<?= htmlspecialchars($d['link']) ?>" target="_blank" class="text-teal-600 hover:underline">
+            <?= htmlspecialchars($d['title']) ?>
+          </a>
+        </li>
+      <?php endforeach; ?>
+    </ul>
+  <?php endif; ?>
 </main>
 <?php include '../footer.php'; ?>

--- a/docs/reference.php
+++ b/docs/reference.php
@@ -1,9 +1,29 @@
 <?php
 $pageTitle = __('home_docs_reference');
+$file = __DIR__ . '/../data/docs.json';
+$docsData = [];
+if (file_exists($file)) {
+    $json = file_get_contents($file);
+    $docsData = json_decode($json, true);
+    if (!is_array($docsData)) $docsData = [];
+}
+$docs = $docsData['reference'] ?? [];
 include '../header.php';
 ?>
 <main class="max-w-3xl mx-auto px-4 py-6">
   <h1 class="text-2xl font-semibold mb-4"><?= __('home_docs_reference') ?></h1>
-  <p>Coming soon...</p>
+  <?php if (empty($docs)): ?>
+    <p>Chưa có tài liệu.</p>
+  <?php else: ?>
+    <ul class="space-y-2">
+      <?php foreach ($docs as $d): ?>
+        <li>
+          <a href="<?= htmlspecialchars($d['link']) ?>" target="_blank" class="text-teal-600 hover:underline">
+            <?= htmlspecialchars($d['title']) ?>
+          </a>
+        </li>
+      <?php endforeach; ?>
+    </ul>
+  <?php endif; ?>
 </main>
 <?php include '../footer.php'; ?>

--- a/lang/en.php
+++ b/lang/en.php
@@ -44,6 +44,7 @@ return [
     'confirm_delete_student' => 'Delete this student?',
     'confirm_delete_article' => 'Delete this article?',
     'confirm_delete_video' => 'Delete this video?',
+    'confirm_delete_doc' => 'Delete this document?',
     'no_student' => 'Student not found!',
     'back' => 'Back',
     'class_login' => 'Login',

--- a/lang/uk.php
+++ b/lang/uk.php
@@ -44,6 +44,7 @@ return [
     'confirm_delete_student' => 'Видалити цього студента?',
     'confirm_delete_article' => 'Видалити цю статтю?',
     'confirm_delete_video' => 'Видалити це відео?',
+    'confirm_delete_doc' => 'Видалити цей документ?',
     'no_student' => 'Студента не знайдено!',
     'back' => 'Назад',
     'class_login' => 'Вхід',

--- a/lang/vi.php
+++ b/lang/vi.php
@@ -44,6 +44,7 @@ return [
     'confirm_delete_student' => 'Xóa học viên này?',
     'confirm_delete_article' => 'Xóa bài viết này?',
     'confirm_delete_video' => 'Xóa video này?',
+    'confirm_delete_doc' => 'Xóa tài liệu này?',
     'no_student' => 'Không tìm thấy học viên!',
     'back' => 'Quay lại',
     'class_login' => 'Đăng nhập',

--- a/tests/DataTest.php
+++ b/tests/DataTest.php
@@ -23,4 +23,14 @@ class DataTest extends TestCase {
         }
         $this->assertTrue(true);
     }
+
+    public function testDocsData() {
+        $data = $this->read(__DIR__ . '/../data/docs.json');
+        if (empty($data)) {
+            $this->markTestSkipped('No docs');
+        }
+        $this->assertArrayHasKey('prayers', $data);
+        $this->assertArrayHasKey('chanting', $data);
+        $this->assertArrayHasKey('reference', $data);
+    }
 }

--- a/tests/RoutesTest.php
+++ b/tests/RoutesTest.php
@@ -19,4 +19,10 @@ class RoutesTest extends TestCase {
     public function testVideosPage() {
         $this->assertEquals(200, $this->request('/videos.php'));
     }
+
+    public function testDocsPages() {
+        $this->assertEquals(200, $this->request('/docs/prayers.php'));
+        $this->assertEquals(200, $this->request('/docs/chanting.php'));
+        $this->assertEquals(200, $this->request('/docs/reference.php'));
+    }
 }


### PR DESCRIPTION
## Summary
- build document pages from `data/docs.json`
- enable admin to manage documents
- add Vietnamese, English and Ukrainian translations for document deletion confirmation
- create tests for docs data and routes
- add blank `docs.json` data file

## Testing
- `php -l admin_panel.php`
- `php -l docs/prayers.php`
- `php -l docs/chanting.php`
- `php -l docs/reference.php`
- `php -l tests/DataTest.php`
- `php -l tests/RoutesTest.php`
- `vendor/bin/phpunit tests` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_6882ed7608d88326817c2688c333d217