### PR TITLE
Fix docs pages layout and translation loading

### DIFF
--- a/docs/chanting.php
+++ b/docs/chanting.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . "/../i18n.php";
 $pageTitle = __('home_docs_chant');
 $file = __DIR__ . '/../data/docs.json';
 $docsData = [];
@@ -11,19 +12,17 @@ $docs = $docsData['chanting'] ?? [];
 include '../header.php';
 ?>
 <main class="max-w-3xl mx-auto px-4 py-6">
-  <h1 class="text-2xl font-semibold mb-4"><?= __('home_docs_chant') ?></h1>
+  <h1 class="text-2xl font-semibold mb-6"><?= __('home_docs_chant') ?></h1>
   <?php if (empty($docs)): ?>
     <p>Chưa có tài liệu.</p>
   <?php else: ?>
-    <ul class="space-y-2">
+    <div class="grid gap-4 sm:grid-cols-2">
       <?php foreach ($docs as $d): ?>
-        <li>
-          <a href="<?= htmlspecialchars($d['link']) ?>" target="_blank" class="text-teal-600 hover:underline">
-            <?= htmlspecialchars($d['title']) ?>
-          </a>
-        </li>
+        <a href="<?= htmlspecialchars($d['link']) ?>" target="_blank" class="block bg-white p-4 rounded-lg shadow hover:shadow-md transition">
+          <?= htmlspecialchars($d['title']) ?>
+        </a>
       <?php endforeach; ?>
-    </ul>
+    </div>
   <?php endif; ?>
 </main>
 <?php include '../footer.php'; ?>

--- a/docs/prayers.php
+++ b/docs/prayers.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . "/../i18n.php";
 $pageTitle = __('home_docs_prayer');
 $file = __DIR__ . '/../data/docs.json';
 $docsData = [];
@@ -11,19 +12,17 @@ $docs = $docsData['prayers'] ?? [];
 include '../header.php';
 ?>
 <main class="max-w-3xl mx-auto px-4 py-6">
-  <h1 class="text-2xl font-semibold mb-4"><?= __('home_docs_prayer') ?></h1>
+  <h1 class="text-2xl font-semibold mb-6"><?= __('home_docs_prayer') ?></h1>
   <?php if (empty($docs)): ?>
     <p>Chưa có tài liệu.</p>
   <?php else: ?>
-    <ul class="space-y-2">
+    <div class="grid gap-4 sm:grid-cols-2">
       <?php foreach ($docs as $d): ?>
-        <li>
-          <a href="<?= htmlspecialchars($d['link']) ?>" target="_blank" class="text-teal-600 hover:underline">
-            <?= htmlspecialchars($d['title']) ?>
-          </a>
-        </li>
+        <a href="<?= htmlspecialchars($d['link']) ?>" target="_blank" class="block bg-white p-4 rounded-lg shadow hover:shadow-md transition">
+          <?= htmlspecialchars($d['title']) ?>
+        </a>
       <?php endforeach; ?>
-    </ul>
+    </div>
   <?php endif; ?>
 </main>
 <?php include '../footer.php'; ?>

--- a/docs/reference.php
+++ b/docs/reference.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . "/../i18n.php";
 $pageTitle = __('home_docs_reference');
 $file = __DIR__ . '/../data/docs.json';
 $docsData = [];
@@ -11,19 +12,17 @@ $docs = $docsData['reference'] ?? [];
 include '../header.php';
 ?>
 <main class="max-w-3xl mx-auto px-4 py-6">
-  <h1 class="text-2xl font-semibold mb-4"><?= __('home_docs_reference') ?></h1>
+  <h1 class="text-2xl font-semibold mb-6"><?= __('home_docs_reference') ?></h1>
   <?php if (empty($docs)): ?>
     <p>Chưa có tài liệu.</p>
   <?php else: ?>
-    <ul class="space-y-2">
+    <div class="grid gap-4 sm:grid-cols-2">
       <?php foreach ($docs as $d): ?>
-        <li>
-          <a href="<?= htmlspecialchars($d['link']) ?>" target="_blank" class="text-teal-600 hover:underline">
-            <?= htmlspecialchars($d['title']) ?>
-          </a>
-        </li>
+        <a href="<?= htmlspecialchars($d['link']) ?>" target="_blank" class="block bg-white p-4 rounded-lg shadow hover:shadow-md transition">
+          <?= htmlspecialchars($d['title']) ?>
+        </a>
       <?php endforeach; ?>
-    </ul>
+    </div>
   <?php endif; ?>
 </main>
 <?php include '../footer.php'; ?>


### PR DESCRIPTION
## Summary
- load i18n before using translation helpers in docs pages
- update documentation pages to use card-based grid layout

## Testing
- `composer install` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_b_6882f1909b5883268b0646ece3eb8b6e