### PR TITLE
Fix i18n loading on Ukraine meditation page

### DIFF
--- a/ukraine_meditation.php
+++ b/ukraine_meditation.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . '/i18n.php';
 $pageTitle = __('ukraine_title');
 $metaDescription = __('ukraine_meta_desc');
 require_once 'header.php';


### PR DESCRIPTION
## Summary
- load i18n before using translation strings in `ukraine_meditation.php`

## Testing
- `php -l ukraine_meditation.php`
- `curl -s http://localhost:8000/ukraine_meditation.php | head`
- `vendor/bin/phpunit --version` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_688311b0bb5c8326b3cd70da09d8c112