### PR TITLE
Improve login security

### DIFF
--- a/config.php
+++ b/config.php
@@ -25,6 +25,12 @@ try {
 
 // Khởi động session (nếu chưa có)
 if (session_status() === PHP_SESSION_NONE) {
+    session_set_cookie_params([
+        'lifetime' => 0,
+        'path'     => '/',
+        'httponly' => true,
+        'samesite' => 'Lax'
+    ]);
     session_start();
 }
 

--- a/login.php
+++ b/login.php
@@ -7,7 +7,8 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST') {
     $stmt = $db->prepare("SELECT * FROM users WHERE email = ?");
     $stmt->execute([$email]);
     $u = $stmt->fetch(PDO::FETCH_ASSOC);
-    if ($u && hash_equals($u['password'], hash('sha256', $pass))) {
+    if ($u && password_verify($pass, $u['password'])) {
+        session_regenerate_id(true);
         $_SESSION['uid'] = $u['id'];
         $_SESSION['role'] = $u['role'];
         header('Location: ' . ($u['role'] === 'admin' ? 'admin.php' : 'dashboard.php'));

--- a/register.php
+++ b/register.php
@@ -20,7 +20,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         if ($stmt->fetch()) {
             $err = __('err_email_exists');
         } else {
-            $hash = hash('sha256', $pass);
+            $hash = password_hash($pass, PASSWORD_DEFAULT);
             $stmt = $db->prepare("INSERT INTO users (role,full_name,email,password,remaining) VALUES ('student',?,?,?,?)");
             $stmt->execute([$name, $email, $hash, $remain]);
             header('Location: admin.php'); exit;


### PR DESCRIPTION
## Summary
- use `password_hash` for storing passwords
- verify passwords via `password_verify`
- regenerate session ID after successful login
- set `HttpOnly` and `SameSite=Lax` on session cookies

## Testing
- `php -l login.php`
- `php -l register.php`
- `php -l config.php`
- `composer install --no-interaction` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_b_688897659e2c83269f65cf2280c9dc1c