### PR TITLE
Implement CSRF tokens

### DIFF
--- a/add_sessions.php
+++ b/add_sessions.php
@@ -7,6 +7,7 @@ if (!isset($_SESSION['uid']) || $_SESSION['role'] !== 'admin') {
 }
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    csrf_check($_POST['csrf_token'] ?? null);
     $uid = intval($_POST['uid'] ?? 0);
     $add = intval($_POST['add'] ?? 0);
 

--- a/admin.php
+++ b/admin.php
@@ -96,6 +96,7 @@ $students = $stmt->fetchAll(PDO::FETCH_ASSOC);
           <td class="px-2 sm:px-3 py-2 text-center flex flex-wrap gap-2 justify-center items-center">
             <!-- CỘNG BUỔI -->
             <form method="post" action="add_sessions.php" class="flex gap-1 items-center">
+              <input type="hidden" name="csrf_token" value="<?= $_SESSION['csrf_token']; ?>">
               <input type="hidden" name="uid" value="<?= $row['id'] ?>">
               <input type="number" name="add" value="1" min="1"
                 class="w-14 rounded border border-mint px-2 py-1 text-sm focus:border-mint-dark focus:ring-mint" />
@@ -104,11 +105,13 @@ $students = $stmt->fetchAll(PDO::FETCH_ASSOC);
               </button>
             </form>
             <!-- XÓA -->
-            <a href="delete_user.php?id=<?= $row['id'] ?>"
-               class="rounded bg-red-100 text-red-700 px-3 py-1 text-xs font-semibold shadow hover:bg-red-400 hover:text-white transition"
-               onclick="return confirm('<?= __('confirm_delete_student') ?>');" title="<?= __('delete') ?> học viên">
-              <?= __('delete') ?>
-            </a>
+            <form method="post" action="delete_user.php" onsubmit="return confirm('<?= __('confirm_delete_student') ?>');" style="display:inline-block">
+              <input type="hidden" name="csrf_token" value="<?= $_SESSION['csrf_token']; ?>">
+              <input type="hidden" name="id" value="<?= $row['id'] ?>">
+              <button class="rounded bg-red-100 text-red-700 px-3 py-1 text-xs font-semibold shadow hover:bg-red-400 hover:text-white transition" title="<?= __('delete') ?> học viên">
+                <?= __('delete') ?>
+              </button>
+            </form>
             <!-- LỊCH SỬ -->
             <a href="history.php?id=<?= $row['id'] ?>"
                class="rounded bg-blue-100 text-blue-700 px-3 py-1 text-xs font-semibold shadow hover:bg-blue-400 hover:text-white transition"

--- a/admin_panel.php
+++ b/admin_panel.php
@@ -34,6 +34,7 @@ $videos   = is_array($videos)   ? $videos   : [];
 $docs = is_array($docs) && isset($docs['prayers']) ? $docs : ['prayers'=>[], 'chanting'=>[], 'reference'=>[]];
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    csrf_check($_POST['csrf_token'] ?? null);
     $action = $_POST['action'] ?? '';
     if ($action === 'add_article') {
         $title = trim($_POST['title'] ?? '');
@@ -198,6 +199,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
   <section class="mb-8">
     <h2 class="text-xl font-semibold mb-4">Thêm bài viết</h2>
     <form method="post" enctype="multipart/form-data" id="article-form" class="space-y-4">
+      <input type="hidden" name="csrf_token" value="<?= $_SESSION['csrf_token']; ?>">
       <input type="hidden" name="action" value="add_article">
       <input type="text" id="article-title" name="title" class="w-full border rounded px-3 py-2" placeholder="<?= __('placeholder_title') ?>" required>
       <input type="url" id="article-link" name="link" class="w-full border rounded px-3 py-2" placeholder="<?= __('placeholder_article_link') ?>" required>
@@ -215,6 +217,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
   <section class="mb-8">
     <h2 class="text-xl font-semibold mb-4"><?= __('button_add_video') ?></h2>
     <form method="post" class="space-y-4">
+      <input type="hidden" name="csrf_token" value="<?= $_SESSION['csrf_token']; ?>">
       <input type="hidden" name="action" value="add_video">
       <input type="text" name="video_title" class="w-full border rounded px-3 py-2" placeholder="<?= __('placeholder_title') ?>" required>
       <input type="url" name="youtube_url" class="w-full border rounded px-3 py-2" placeholder="<?= __('placeholder_youtube') ?>" required>
@@ -225,6 +228,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
   <section class="mb-8">
     <h2 class="text-xl font-semibold mb-4"><?= __('button_add_doc') ?></h2>
     <form method="post" class="space-y-4">
+      <input type="hidden" name="csrf_token" value="<?= $_SESSION['csrf_token']; ?>">
       <input type="hidden" name="action" value="add_doc">
       <select name="category" class="w-full border rounded px-3 py-2" required>
         <option value="prayers"><?= __('home_docs_prayer') ?></option>
@@ -251,6 +255,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             <div class="flex items-center gap-2">
               <?php if ($i > 0): ?>
                 <form method="post">
+                  <input type="hidden" name="csrf_token" value="<?= $_SESSION['csrf_token']; ?>">
                   <input type="hidden" name="action" value="move_doc">
                   <input type="hidden" name="category" value="prayers">
                   <input type="hidden" name="dir" value="up">
@@ -260,6 +265,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
               <?php endif; ?>
               <?php if ($i < count($docs['prayers']) - 1): ?>
                 <form method="post">
+                  <input type="hidden" name="csrf_token" value="<?= $_SESSION['csrf_token']; ?>">
                   <input type="hidden" name="action" value="move_doc">
                   <input type="hidden" name="category" value="prayers">
                   <input type="hidden" name="dir" value="down">
@@ -268,6 +274,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 </form>
               <?php endif; ?>
               <form method="post" onsubmit="return confirm('<?= __('confirm_delete_doc') ?>');">
+                <input type="hidden" name="csrf_token" value="<?= $_SESSION['csrf_token']; ?>">
                 <input type="hidden" name="action" value="delete_doc">
                 <input type="hidden" name="category" value="prayers">
                 <input type="hidden" name="index" value="<?= $i ?>">
@@ -294,6 +301,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             <div class="flex items-center gap-2">
               <?php if ($i > 0): ?>
                 <form method="post">
+                  <input type="hidden" name="csrf_token" value="<?= $_SESSION['csrf_token']; ?>">
                   <input type="hidden" name="action" value="move_doc">
                   <input type="hidden" name="category" value="chanting">
                   <input type="hidden" name="dir" value="up">
@@ -303,6 +311,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
               <?php endif; ?>
               <?php if ($i < count($docs['chanting']) - 1): ?>
                 <form method="post">
+                  <input type="hidden" name="csrf_token" value="<?= $_SESSION['csrf_token']; ?>">
                   <input type="hidden" name="action" value="move_doc">
                   <input type="hidden" name="category" value="chanting">
                   <input type="hidden" name="dir" value="down">
@@ -311,6 +320,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 </form>
               <?php endif; ?>
               <form method="post" onsubmit="return confirm('<?= __('confirm_delete_doc') ?>');">
+                <input type="hidden" name="csrf_token" value="<?= $_SESSION['csrf_token']; ?>">
                 <input type="hidden" name="action" value="delete_doc">
                 <input type="hidden" name="category" value="chanting">
                 <input type="hidden" name="index" value="<?= $i ?>">
@@ -337,6 +347,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             <div class="flex items-center gap-2">
               <?php if ($i > 0): ?>
                 <form method="post">
+                  <input type="hidden" name="csrf_token" value="<?= $_SESSION['csrf_token']; ?>">
                   <input type="hidden" name="action" value="move_doc">
                   <input type="hidden" name="category" value="reference">
                   <input type="hidden" name="dir" value="up">
@@ -346,6 +357,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
               <?php endif; ?>
               <?php if ($i < count($docs['reference']) - 1): ?>
                 <form method="post">
+                  <input type="hidden" name="csrf_token" value="<?= $_SESSION['csrf_token']; ?>">
                   <input type="hidden" name="action" value="move_doc">
                   <input type="hidden" name="category" value="reference">
                   <input type="hidden" name="dir" value="down">
@@ -354,6 +366,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 </form>
               <?php endif; ?>
               <form method="post" onsubmit="return confirm('<?= __('confirm_delete_doc') ?>');">
+                <input type="hidden" name="csrf_token" value="<?= $_SESSION['csrf_token']; ?>">
                 <input type="hidden" name="action" value="delete_doc">
                 <input type="hidden" name="category" value="reference">
                 <input type="hidden" name="index" value="<?= $i ?>">
@@ -378,6 +391,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             <div class="flex items-center gap-2">
               <?php if ($i > 0): ?>
                 <form method="post">
+                  <input type="hidden" name="csrf_token" value="<?= $_SESSION['csrf_token']; ?>">
                   <input type="hidden" name="action" value="move_article">
                   <input type="hidden" name="dir" value="up">
                   <input type="hidden" name="index" value="<?= $i ?>">
@@ -386,6 +400,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
               <?php endif; ?>
               <?php if ($i < count($articles) - 1): ?>
                 <form method="post">
+                  <input type="hidden" name="csrf_token" value="<?= $_SESSION['csrf_token']; ?>">
                   <input type="hidden" name="action" value="move_article">
                   <input type="hidden" name="dir" value="down">
                   <input type="hidden" name="index" value="<?= $i ?>">
@@ -393,6 +408,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 </form>
               <?php endif; ?>
               <form method="post" onsubmit="return confirm('<?= __('confirm_delete_article') ?>');">
+                <input type="hidden" name="csrf_token" value="<?= $_SESSION['csrf_token']; ?>">
                 <input type="hidden" name="action" value="delete_article">
                 <input type="hidden" name="index" value="<?= $i ?>">
                 <button class="text-red-600 hover:underline"><?= __('delete') ?></button>
@@ -416,6 +432,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             <div class="flex items-center gap-2">
               <?php if ($i > 0): ?>
                 <form method="post">
+                  <input type="hidden" name="csrf_token" value="<?= $_SESSION['csrf_token']; ?>">
                   <input type="hidden" name="action" value="move_video">
                   <input type="hidden" name="dir" value="up">
                   <input type="hidden" name="index" value="<?= $i ?>">
@@ -424,6 +441,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
               <?php endif; ?>
               <?php if ($i < count($videos) - 1): ?>
                 <form method="post">
+                  <input type="hidden" name="csrf_token" value="<?= $_SESSION['csrf_token']; ?>">
                   <input type="hidden" name="action" value="move_video">
                   <input type="hidden" name="dir" value="down">
                   <input type="hidden" name="index" value="<?= $i ?>">
@@ -431,6 +449,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 </form>
               <?php endif; ?>
               <form method="post" onsubmit="return confirm('<?= __('confirm_delete_video') ?>');">
+                <input type="hidden" name="csrf_token" value="<?= $_SESSION['csrf_token']; ?>">
                 <input type="hidden" name="action" value="delete_video">
                 <input type="hidden" name="index" value="<?= $i ?>">
                 <button class="text-red-600 hover:underline"><?= __('delete') ?></button>

--- a/config.php
+++ b/config.php
@@ -34,6 +34,18 @@ if (session_status() === PHP_SESSION_NONE) {
     session_start();
 }
 
+// CSRF token utilities
+if (empty($_SESSION['csrf_token'])) {
+    $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+}
+
+function csrf_check(?string $token): void {
+    if (!isset($_SESSION['csrf_token']) || !is_string($token) || !hash_equals($_SESSION['csrf_token'], $token)) {
+        http_response_code(400);
+        exit('Invalid CSRF token');
+    }
+}
+
 // Nạp file đa ngôn ngữ (nếu có)
 require_once __DIR__ . '/i18n.php';
 

--- a/delete_user.php
+++ b/delete_user.php
@@ -5,7 +5,11 @@ if (!isset($_SESSION['uid']) || $_SESSION['role'] !== 'admin') {
     exit;
 }
 
-$id = intval($_GET['id'] ?? 0);
+$id = 0;
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    csrf_check($_POST['csrf_token'] ?? null);
+    $id = intval($_POST['id'] ?? 0);
+}
 if ($id) {
     // 1) Xóa trước tất cả lịch sử sessions của user này
     $db->prepare("DELETE FROM sessions WHERE user_id = ?")->execute([$id]);

--- a/login.php
+++ b/login.php
@@ -2,6 +2,7 @@
 require 'config.php';
 $err = "";
 if ($_SERVER['REQUEST_METHOD'] == 'POST') {
+    csrf_check($_POST['csrf_token'] ?? null);
     $email = $_POST['email'] ?? '';
     $pass = $_POST['password'] ?? '';
     $stmt = $db->prepare("SELECT * FROM users WHERE email = ?");
@@ -27,6 +28,7 @@ include 'header.php';
       <div class="bg-red-50 border border-red-300 text-red-700 rounded-md px-3 py-2 text-sm mb-4 text-center"><?= htmlspecialchars($err) ?></div>
     <?php endif; ?>
     <form method="post" autocomplete="off" class="space-y-5">
+      <input type="hidden" name="csrf_token" value="<?= $_SESSION['csrf_token']; ?>">
       <div>
         <label class="block text-sm font-medium text-[#285F57] mb-1"><?= __('email_label') ?></label>
         <input name="email" type="text" required autofocus

--- a/register.php
+++ b/register.php
@@ -6,6 +6,7 @@ if (!isset($_SESSION['uid']) || $_SESSION['role'] !== 'admin') {
 
 $err = "";
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    csrf_check($_POST['csrf_token'] ?? null);
     $name  = trim($_POST['full_name'] ?? '');
     $email = trim($_POST['email'] ?? '');
     $pass  = $_POST['password'] ?? '';
@@ -40,6 +41,7 @@ require 'header.php';
       </div>
     <?php endif; ?>
     <form method="post" class="space-y-4">
+      <input type="hidden" name="csrf_token" value="<?= $_SESSION['csrf_token']; ?>">
       <div>
         <label class="block text-sm font-medium text-mint-text mb-1"><?= __('name_label') ?></label>
         <input type="text" name="full_name" class="w-full px-3 py-2 border border-mint rounded-lg bg-gray-50 text-gray-800 focus:outline-none focus:border-mint-dark focus:bg-white transition" required>


### PR DESCRIPTION
## Summary
- generate CSRF token on session start
- verify token on POST requests
- embed token in all data-changing forms
- switch user deletion to POST

## Testing
- `php -l config.php`
- `php -l register.php`
- `php -l login.php`
- `php -l admin_panel.php`
- `php -l add_sessions.php`
- `php -l delete_user.php`
- `php -l admin.php`
- `composer install` *(fails: CONNECT tunnel failed)*
- `phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6888982b257083269aa130fe830ea952