### PR TITLE
Enhance signup flow with discount and health confirmation

### DIFF
--- a/signup.php
+++ b/signup.php
@@ -29,7 +29,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['pay_vnpay'])) {
         'vnp_CurrCode'  => 'VND',
         'vnp_IpAddr'    => $_SERVER['REMOTE_ADDR'],
         'vnp_Locale'    => 'vn',
-        'vnp_OrderInfo' => 'Thanh toan khoa thien NamaHealing',
+        'vnp_OrderInfo' => 'Thanh toan khoa thien NamaHealing - ' . $order['full_name'] . ' - ' . $order['phone'],
         'vnp_OrderType' => 'billpayment',
         'vnp_ReturnUrl' => $vnp_Returnurl,
         'vnp_TxnRef'    => $order['txnRef'],
@@ -47,11 +47,19 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['pay_vnpay'])) {
 // Step 1: handle form submission and show confirmation
 if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['create_order'])) {
     csrf_check($_POST['csrf_token'] ?? null);
-    $name     = trim($_POST['full_name'] ?? '');
-    $email    = trim($_POST['email'] ?? '');
-    $sessions = max(1, (int)($_POST['sessions'] ?? 0));
-    $pricePer = (int)($_ENV['SESSION_PRICE'] ?? 100000); // VND per session
-    $amount   = $sessions * $pricePer;
+    $name   = trim($_POST['full_name'] ?? '');
+    $email  = trim($_POST['email'] ?? '');
+    $phone  = trim($_POST['phone'] ?? '');
+    $mental = isset($_POST['mental_health']);
+    $aid    = isset($_POST['financial_aid']);
+    if (!$mental) {
+        $error = 'Lớp thiền chỉ dành cho người mắc các triệu chứng tâm lí, người bình thường có thể đến chùa, thiền viện để thực hành.';
+        include __DIR__ . '/views/signup_form.php';
+        exit;
+    }
+
+    $sessions = 20;
+    $amount   = $aid ? 5000000 : 8000000;
     $txnRef   = (string)time();
 
     $model = new OrderModel($db);
@@ -61,6 +69,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['create_order'])) {
         'txnRef'   => $txnRef,
         'full_name'=> $name,
         'email'    => $email,
+        'phone'    => $phone,
         'sessions' => $sessions,
         'amount'   => $amount,
     ];

--- a/views/confirm_order.php
+++ b/views/confirm_order.php
@@ -2,18 +2,25 @@
 <main class="min-h-[75vh] flex items-center justify-center py-12">
   <div class="w-full max-w-md bg-white/90 rounded-xl shadow-lg p-8">
     <h2 class="text-center text-2xl font-bold mb-6">Xác nhận đơn hàng</h2>
-    <div class="space-y-2 mb-4">
+    <div class="space-y-2 mb-6">
       <div><strong>Họ tên:</strong> <?= htmlspecialchars($order['full_name']) ?></div>
       <div><strong>Email:</strong> <?= htmlspecialchars($order['email']) ?></div>
+      <div><strong>Số điện thoại:</strong> <?= htmlspecialchars($order['phone']) ?></div>
       <div><strong>Số buổi:</strong> <?= (int)$order['sessions'] ?></div>
       <div><strong>Thanh toán:</strong> <?= number_format($order['amount']) ?> VND</div>
     </div>
-    <form method="post">
-      <input type="hidden" name="csrf_token" value="<?= $_SESSION['csrf_token']; ?>">
-      <button name="pay_vnpay" class="w-full bg-[#9dcfc3] text-[#285F57] font-semibold py-2 rounded-lg">
-        Thanh toán bằng VNPay QR
+    <h3 class="text-center font-semibold mb-4">Chọn phương thức thanh toán</h3>
+    <div class="flex flex-col space-y-2">
+      <form method="post">
+        <input type="hidden" name="csrf_token" value="<?= $_SESSION['csrf_token']; ?>">
+        <button name="pay_vnpay" class="w-full bg-[#9dcfc3] text-[#285F57] font-semibold py-2 rounded-lg">
+          Thanh toán VNPay
+        </button>
+      </form>
+      <button class="w-full bg-gray-300 text-gray-600 font-semibold py-2 rounded-lg" disabled>
+        Thanh toán MoMo (đang phát triển)
       </button>
-    </form>
+    </div>
   </div>
 </main>
 <?php include 'footer.php'; ?>

--- a/views/signup_form.php
+++ b/views/signup_form.php
@@ -2,8 +2,11 @@
 <main class="min-h-[75vh] flex items-center justify-center py-12">
   <div class="w-full max-w-md bg-white/90 rounded-xl shadow-lg p-8">
     <h2 class="text-center text-2xl font-bold mb-6">Đăng ký lớp thiền</h2>
-    <form method="post" class="space-y-4">
+    <form method="post" class="space-y-4" id="signup-form">
       <input type="hidden" name="csrf_token" value="<?= $_SESSION['csrf_token']; ?>">
+      <?php if (!empty($error)): ?>
+      <div class="text-red-600 text-sm"><?= htmlspecialchars($error) ?></div>
+      <?php endif; ?>
       <div>
         <label class="block mb-1">Họ tên</label>
         <input type="text" name="full_name" required class="w-full px-4 py-2 border rounded-lg" />
@@ -13,11 +16,35 @@
         <input type="email" name="email" required class="w-full px-4 py-2 border rounded-lg" />
       </div>
       <div>
-        <label class="block mb-1">Số buổi</label>
-        <input type="number" name="sessions" value="1" min="1" class="w-full px-4 py-2 border rounded-lg" />
+        <label class="block mb-1">Số điện thoại</label>
+        <input type="tel" name="phone" required class="w-full px-4 py-2 border rounded-lg" />
       </div>
-      <button class="w-full bg-[#9dcfc3] text-[#285F57] font-semibold py-2 rounded-lg" name="create_order">Tiếp tục</button>
+      <div>
+        <label class="block mb-1">Số buổi</label>
+        <input type="text" value="20" disabled class="w-full px-4 py-2 border rounded-lg bg-gray-100" />
+        <input type="hidden" name="sessions" value="20" />
+      </div>
+      <div>
+        <label class="block mb-1">Học phí</label>
+        <input type="text" id="tuition" value="8,000,000 VND" disabled class="w-full px-4 py-2 border rounded-lg bg-gray-100" />
+      </div>
+      <div class="flex items-center">
+        <input type="checkbox" id="financial_aid" name="financial_aid" class="mr-2">
+        <label for="financial_aid" class="text-sm">Tôi hiện đang sống ở Việt Nam và gặp khó khăn về vấn đề tài chính</label>
+      </div>
+      <div class="flex items-start">
+        <input type="checkbox" id="mental_health" name="mental_health" class="mr-2 mt-1" required>
+        <label for="mental_health" class="text-sm">Tôi hiện đang mắc một trong các triệu chứng tâm lý như trầm cảm, rối loạn lo âu, rối loạn lưỡng cực, mất ngủ, căng thẳng, stress,...</label>
+      </div>
+      <button class="w-full bg-[#9dcfc3] text-[#285F57] font-semibold py-2 rounded-lg" name="create_order">Đăng ký</button>
     </form>
+    <script>
+      const financial = document.getElementById('financial_aid');
+      const tuition = document.getElementById('tuition');
+      financial.addEventListener('change', () => {
+        tuition.value = financial.checked ? '5,000,000 VND' : '8,000,000 VND';
+      });
+    </script>
   </div>
 </main>
 <?php include 'footer.php'; ?>


### PR DESCRIPTION
## Summary
- Add phone field, fixed 20 sessions, financial aid and mental health checkboxes in signup form
- Enforce mental-health confirmation, discount logic, and pass name+phone to VNPay
- Show phone and payment method options (VNPay, placeholder MoMo) on confirmation page

## Testing
- `composer install` (failed: Required package "phpmailer/phpmailer" is not present in the lock file)
- `./vendor/bin/phpunit` (failed: No such file or directory)


------
https://chatgpt.com/codex/tasks/task_b_689034713ae08326a4f84e438193b998