### PR TITLE
Implement self-registration with email verification

### DIFF
--- a/controllers/LoginController.php
+++ b/controllers/LoginController.php
@@ -20,13 +20,17 @@ class LoginController {
             $model = new UserModel($this->db);
             $user  = $model->findByEmail($email);
             if ($user && password_verify($pass, $user['password'])) {
-                session_regenerate_id(true);
-                $_SESSION['uid']  = $user['id'];
-                $_SESSION['role'] = $user['role'];
-                header('Location: ' . ($user['role'] === 'admin' ? 'admin.php' : 'dashboard.php'));
-                exit;
+                if (!empty($user['verified'])) {
+                    session_regenerate_id(true);
+                    $_SESSION['uid']  = $user['id'];
+                    $_SESSION['role'] = $user['role'];
+                    header('Location: ' . ($user['role'] === 'admin' ? 'admin.php' : 'dashboard.php'));
+                    exit;
+                }
+                $err = 'Tài khoản chưa được xác thực.';
+            } else {
+                $err = __('login_error');
             }
-            $err = __('login_error');
         }
         include __DIR__ . '/../views/login.php';
     }

--- a/controllers/SelfRegisterController.php
+++ b/controllers/SelfRegisterController.php
@@ -1,0 +1,48 @@
+<?php
+namespace NamaHealing\Controllers;
+
+use PDO;
+use NamaHealing\Models\UserModel;
+use NamaHealing\Helpers\Recaptcha;
+use NamaHealing\Helpers\Mailer;
+
+class SelfRegisterController {
+    private PDO $db;
+
+    public function __construct(PDO $db) {
+        $this->db = $db;
+    }
+
+    public function handle(): void {
+        $err = "";
+        $done = false;
+        if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+            csrf_check($_POST['csrf_token'] ?? null);
+            $captcha = $_POST['g-recaptcha-response'] ?? ($_POST['recaptcha_token'] ?? '');
+            if (!Recaptcha::verify($captcha)) {
+                $err = 'reCAPTCHA validation failed';
+            } else {
+                $name  = trim($_POST['full_name'] ?? '');
+                $email = trim($_POST['email'] ?? '');
+                $pass  = $_POST['password'] ?? '';
+                if (!$name || !$email || !$pass) {
+                    $err = 'Vui lòng nhập đầy đủ thông tin';
+                } else {
+                    $model = new UserModel($this->db);
+                    if ($model->findByEmail($email)) {
+                        $err = 'Email đã được sử dụng';
+                    } else {
+                        $verifyToken = bin2hex(random_bytes(16));
+                        $model->createStudent($name, $email, $pass, 0, 0, $verifyToken);
+                        $link = ($_ENV['APP_URL'] ?? '') . '/verify.php?token=' . urlencode($verifyToken);
+                        $body = 'Vui lòng xác thực tài khoản của bạn bằng cách nhấp vào liên kết sau: <a href="' .
+                            $link . '">' . $link . '</a>';
+                        Mailer::send($email, 'Xác thực tài khoản NamaHealing', $body);
+                        $done = true;
+                    }
+                }
+            }
+        }
+        include __DIR__ . '/../views/self_register.php';
+    }
+}

--- a/helpers/Recaptcha.php
+++ b/helpers/Recaptcha.php
@@ -1,0 +1,16 @@
+<?php
+namespace NamaHealing\Helpers;
+
+class Recaptcha {
+    public static function verify(string $token): bool {
+        $secret = $_ENV['RECAPTCHA_SECRET'] ?? '';
+        if (!$secret || !$token) {
+            return false;
+        }
+        $resp = @file_get_contents('https://www.google.com/recaptcha/api/siteverify?secret='.
+            urlencode($secret).'&response='.urlencode($token));
+        if (!$resp) return false;
+        $data = json_decode($resp, true);
+        return !empty($data['success']) && ($data['score'] ?? 0) >= 0.5;
+    }
+}

--- a/models/UserModel.php
+++ b/models/UserModel.php
@@ -17,9 +17,18 @@ class UserModel {
         return $row ?: null;
     }
 
-    public function createStudent(string $name, string $email, string $pass, int $remain): void {
+    public function createStudent(
+        string $name,
+        string $email,
+        string $pass,
+        int $remain = 0,
+        int $verified = 0,
+        ?string $token = null
+    ): void {
         $hash = password_hash($pass, PASSWORD_DEFAULT);
-        $stmt = $this->db->prepare("INSERT INTO users (role,full_name,email,password,remaining) VALUES ('student',?,?,?,?)");
-        $stmt->execute([$name, $email, $hash, $remain]);
+        $stmt = $this->db->prepare(
+            "INSERT INTO users (role,full_name,email,password,remaining,verified,verify_token) VALUES ('student',?,?,?,?,?,?)"
+        );
+        $stmt->execute([$name, $email, $hash, $remain, $verified, $token]);
     }
 }

--- a/register.php
+++ b/register.php
@@ -1,7 +1,7 @@
 <?php
 require 'config.php';
 
-use NamaHealing\Controllers\RegisterController;
+use NamaHealing\Controllers\SelfRegisterController;
 
-$controller = new RegisterController($db);
+$controller = new SelfRegisterController($db);
 $controller->handle();

--- a/verify.php
+++ b/verify.php
@@ -1,0 +1,23 @@
+<?php
+require 'config.php';
+
+$token = $_GET['token'] ?? '';
+$verified = false;
+if ($token) {
+    $stmt = $db->prepare('UPDATE users SET verified=1, verify_token=NULL WHERE verify_token=?');
+    $stmt->execute([$token]);
+    $verified = $stmt->rowCount() > 0;
+}
+
+include 'header.php';
+?>
+<main class="min-h-[75vh] flex items-center justify-center">
+  <div class="bg-white/90 rounded-xl shadow-lg p-8 text-center">
+    <?php if ($verified): ?>
+      <p>Tài khoản của bạn đã được xác thực. <a href="login.php" class="text-blue-600 underline">Đăng nhập</a></p>
+    <?php else: ?>
+      <p>Token không hợp lệ hoặc đã được sử dụng.</p>
+    <?php endif; ?>
+  </div>
+</main>
+<?php include 'footer.php'; ?>

--- a/views/self_register.php
+++ b/views/self_register.php
@@ -1,0 +1,40 @@
+<?php include 'header.php'; ?>
+<main class="min-h-[75vh] flex items-center justify-center py-12">
+  <div class="w-full max-w-md bg-white/90 rounded-xl shadow-lg p-8">
+    <h2 class="text-center text-2xl font-bold mb-6">Đăng ký tài khoản</h2>
+    <?php if ($done): ?>
+      <div class="text-green-600 text-sm mb-4">Vui lòng kiểm tra email để xác thực tài khoản.</div>
+    <?php endif; ?>
+    <?php if (!empty($err)): ?>
+      <div class="text-red-600 text-sm mb-4"><?= htmlspecialchars($err) ?></div>
+    <?php endif; ?>
+    <form method="post" class="space-y-4">
+      <input type="hidden" name="csrf_token" value="<?= $_SESSION['csrf_token']; ?>">
+      <div>
+        <label class="block mb-1">Họ tên</label>
+        <input type="text" name="full_name" required class="w-full px-4 py-2 border rounded-lg" />
+      </div>
+      <div>
+        <label class="block mb-1">Email</label>
+        <input type="email" name="email" required class="w-full px-4 py-2 border rounded-lg" />
+      </div>
+      <div>
+        <label class="block mb-1">Mật khẩu</label>
+        <input type="password" name="password" required class="w-full px-4 py-2 border rounded-lg" />
+      </div>
+      <?php $siteKey = $_ENV['RECAPTCHA_SITE_KEY'] ?? ''; $version = $_ENV['RECAPTCHA_VERSION'] ?? 'v2'; ?>
+      <?php if ($version === 'v3'): ?>
+        <input type="hidden" name="recaptcha_token" id="recaptcha_token">
+        <script src="https://www.google.com/recaptcha/api.js?render=<?= $siteKey ?>"></script>
+        <script>
+        grecaptcha.ready(function(){grecaptcha.execute('<?= $siteKey ?>',{action:'register'}).then(function(token){document.getElementById('recaptcha_token').value = token;});});
+        </script>
+      <?php else: ?>
+        <div class="g-recaptcha" data-sitekey="<?= $siteKey ?>"></div>
+        <script src="https://www.google.com/recaptcha/api.js" async defer></script>
+      <?php endif; ?>
+      <button class="w-full bg-[#9dcfc3] text-[#285F57] font-semibold py-2 rounded-lg">Đăng ký</button>
+    </form>
+  </div>
+</main>
+<?php include 'footer.php'; ?>


### PR DESCRIPTION
## Summary
- allow students to self-register via new controller and register page with reCAPTCHA
- send verification email and block login until verified
- add verify endpoint and user model support for tokens

## Testing
- `composer update phpmailer/phpmailer vlucas/phpdotenv` *(fails: curl error 56 CONNECT tunnel failed 403)*
- `apt-get update` *(fails: repository InRelease 403 Forbidden)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_6890f5b943f0832687bc6860ebd1a3f7