### PR TITLE
Enable phone login and simplify registration

### DIFF
--- a/controllers/LoginController.php
+++ b/controllers/LoginController.php
@@ -15,22 +15,18 @@ class LoginController {
         $err = "";
         if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             csrf_check($_POST['csrf_token'] ?? null);
-            $email = $_POST['email'] ?? '';
-            $pass  = $_POST['password'] ?? '';
-            $model = new UserModel($this->db);
-            $user  = $model->findByEmail($email);
+            $identifier = $_POST['email'] ?? '';
+            $pass       = $_POST['password'] ?? '';
+            $model      = new UserModel($this->db);
+            $user       = $model->findByEmailOrPhone($identifier);
             if ($user && password_verify($pass, $user['password'])) {
-                if (!empty($user['verified'])) {
-                    session_regenerate_id(true);
-                    $_SESSION['uid']  = $user['id'];
-                    $_SESSION['role'] = $user['role'];
-                    header('Location: ' . ($user['role'] === 'admin' ? 'admin.php' : 'dashboard.php'));
-                    exit;
-                }
-                $err = 'Tài khoản chưa được xác thực.';
-            } else {
-                $err = __('login_error');
+                session_regenerate_id(true);
+                $_SESSION['uid']  = $user['id'];
+                $_SESSION['role'] = $user['role'];
+                header('Location: ' . ($user['role'] === 'admin' ? 'admin.php' : 'dashboard.php'));
+                exit;
             }
+            $err = __('login_error');
         }
         include __DIR__ . '/../views/login.php';
     }

--- a/controllers/RegisterController.php
+++ b/controllers/RegisterController.php
@@ -19,18 +19,19 @@ class RegisterController {
         $err = "";
         if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             csrf_check($_POST['csrf_token'] ?? null);
-            $name  = trim($_POST['full_name'] ?? '');
-            $email = trim($_POST['email'] ?? '');
-            $pass  = $_POST['password'] ?? '';
-            $remain= intval($_POST['remaining'] ?? 0);
-            if (!$name || !$email || !$pass) {
+            $name   = trim($_POST['full_name'] ?? '');
+            $email  = trim($_POST['email'] ?? '');
+            $phone  = trim($_POST['phone'] ?? '');
+            $pass   = $_POST['password'] ?? '';
+            $remain = intval($_POST['remaining'] ?? 0);
+            if (!$name || !$email || !$phone || !$pass) {
                 $err = __('err_required_fields');
             } else {
                 $model = new UserModel($this->db);
-                if ($model->findByEmail($email)) {
+                if ($model->findByEmailOrPhone($email) || $model->findByEmailOrPhone($phone)) {
                     $err = __('err_email_exists');
                 } else {
-                    $model->createStudent($name, $email, $pass, $remain);
+                    $model->createStudent($name, $email, $phone, $pass, $remain);
                     header('Location: admin.php');
                     exit;
                 }

--- a/controllers/SelfRegisterController.php
+++ b/controllers/SelfRegisterController.php
@@ -3,8 +3,6 @@ namespace NamaHealing\Controllers;
 
 use PDO;
 use NamaHealing\Models\UserModel;
-use NamaHealing\Helpers\Recaptcha;
-use NamaHealing\Helpers\Mailer;
 
 class SelfRegisterController {
     private PDO $db;
@@ -18,28 +16,19 @@ class SelfRegisterController {
         $done = false;
         if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             csrf_check($_POST['csrf_token'] ?? null);
-            $captcha = $_POST['g-recaptcha-response'] ?? ($_POST['recaptcha_token'] ?? '');
-            if (!Recaptcha::verify($captcha)) {
-                $err = 'reCAPTCHA validation failed';
+            $name  = trim($_POST['full_name'] ?? '');
+            $email = trim($_POST['email'] ?? '');
+            $phone = trim($_POST['phone'] ?? '');
+            $pass  = $_POST['password'] ?? '';
+            if (!$name || !$email || !$phone || !$pass) {
+                $err = 'Vui lòng nhập đầy đủ thông tin';
             } else {
-                $name  = trim($_POST['full_name'] ?? '');
-                $email = trim($_POST['email'] ?? '');
-                $pass  = $_POST['password'] ?? '';
-                if (!$name || !$email || !$pass) {
-                    $err = 'Vui lòng nhập đầy đủ thông tin';
+                $model = new UserModel($this->db);
+                if ($model->findByEmailOrPhone($email) || $model->findByEmailOrPhone($phone)) {
+                    $err = 'Email hoặc số điện thoại đã được sử dụng';
                 } else {
-                    $model = new UserModel($this->db);
-                    if ($model->findByEmail($email)) {
-                        $err = 'Email đã được sử dụng';
-                    } else {
-                        $verifyToken = bin2hex(random_bytes(16));
-                        $model->createStudent($name, $email, $pass, 0, 0, $verifyToken);
-                        $link = ($_ENV['APP_URL'] ?? '') . '/verify.php?token=' . urlencode($verifyToken);
-                        $body = 'Vui lòng xác thực tài khoản của bạn bằng cách nhấp vào liên kết sau: <a href="' .
-                            $link . '">' . $link . '</a>';
-                        Mailer::send($email, 'Xác thực tài khoản NamaHealing', $body);
-                        $done = true;
-                    }
+                    $model->createStudent($name, $email, $phone, $pass);
+                    $done = true;
                 }
             }
         }

--- a/lang/en.php
+++ b/lang/en.php
@@ -4,6 +4,7 @@ return [
     'logout_button' => 'Logout',
     'login_heading' => 'Class Login',
     'email_label' => 'Email / Phone',
+    'phone_label' => 'Phone',
     'password_label' => 'Password',
     'email_placeholder' => 'Enter email or phone...',
     'password_placeholder' => 'Enter password...',

--- a/lang/uk.php
+++ b/lang/uk.php
@@ -4,6 +4,7 @@ return [
     'logout_button' => 'Вийти',
     'login_heading' => 'Вхід до класу',
     'email_label' => 'Email / Телефон',
+    'phone_label' => 'Телефон',
     'password_label' => 'Пароль',
     'email_placeholder' => 'Введіть email або телефон...',
     'password_placeholder' => 'Введіть пароль...',

--- a/lang/vi.php
+++ b/lang/vi.php
@@ -4,6 +4,7 @@ return [
     'logout_button' => 'Đăng xuất',
     'login_heading' => 'Đăng nhập lớp học',
     'email_label' => 'Email / Số điện thoại',
+    'phone_label' => 'Số điện thoại',
     'password_label' => 'Mật khẩu',
     'email_placeholder' => 'Nhập email hoặc SĐT...',
     'password_placeholder' => 'Nhập mật khẩu...',

--- a/models/UserModel.php
+++ b/models/UserModel.php
@@ -10,9 +10,9 @@ class UserModel {
         $this->db = $db;
     }
 
-    public function findByEmail(string $email): ?array {
-        $stmt = $this->db->prepare('SELECT * FROM users WHERE email = ?');
-        $stmt->execute([$email]);
+    public function findByEmailOrPhone(string $identifier): ?array {
+        $stmt = $this->db->prepare('SELECT * FROM users WHERE email = ? OR phone = ?');
+        $stmt->execute([$identifier, $identifier]);
         $row = $stmt->fetch(PDO::FETCH_ASSOC);
         return $row ?: null;
     }
@@ -20,15 +20,14 @@ class UserModel {
     public function createStudent(
         string $name,
         string $email,
+        string $phone,
         string $pass,
-        int $remain = 0,
-        int $verified = 0,
-        ?string $token = null
+        int $remain = 0
     ): void {
         $hash = password_hash($pass, PASSWORD_DEFAULT);
         $stmt = $this->db->prepare(
-            "INSERT INTO users (role,full_name,email,password,remaining,verified,verify_token) VALUES ('student',?,?,?,?,?,?)"
+            "INSERT INTO users (role,full_name,email,phone,password,remaining,verified,verify_token) VALUES ('student',?,?,?,?,?,1,NULL)"
         );
-        $stmt->execute([$name, $email, $hash, $remain, $verified, $token]);
+        $stmt->execute([$name, $email, $phone, $hash, $remain]);
     }
 }

--- a/views/login.php
+++ b/views/login.php
@@ -25,76 +25,9 @@
     </form>
     <div class="mt-5 text-center text-sm text-gray-500">
       <?= __('no_account') ?>
-      <a href="#" id="open-register-modal" class="text-[#285F57] hover:underline font-medium transition"><?= __('register_link') ?></a>
+      <a href="register.php" class="text-[#285F57] hover:underline font-medium transition"><?= __('register_link') ?></a>
     </div>
   </div>
 </main>
-
-<!-- Modal: Hướng dẫn đăng ký lớp học (từ home.php) -->
-<div id="register-modal" class="fixed inset-0 z-50 flex items-center justify-center bg-black/40 hidden">
-  <div class="bg-white rounded-2xl w-[96vw] max-w-lg p-4 sm:p-6 relative shadow-2xl overflow-y-auto max-h-[95vh] leading-relaxed">
-    <div class="mb-3 px-2 py-2 bg-red-50 border border-red-300 rounded text-red-700 text-base font-semibold text-center tracking-wider leading-snug">
-      <span class="uppercase font-bold block">
-        <?= __('register_warning_line1') ?>
-      </span>
-      <span class="block mt-1 text-red-700">
-        <?= __('register_warning_line2') ?>
-      </span>
-    </div>
-    <button id="close-register-modal" class="absolute top-2 right-2 w-10 h-10 rounded-full bg-gray-100 hover:bg-gray-200 flex items-center justify-center text-xl font-bold z-10">&times;</button>
-    <div class="text-lg font-semibold mb-2 text-center mt-1"><?= __('register_guide_title') ?></div>
-    <ol class="list-decimal pl-5 sm:pl-6 text-base mb-4 space-y-3">
-      <li>
-        <span class="font-medium"><?= __('register_time_title') ?></span>
-        <?= __('register_time_desc') ?>
-        <ul class="list-disc pl-5 sm:pl-6 space-y-1">
-          <li><?= __('register_time_morning') ?></li>
-          <li><?= __('register_time_evening') ?></li>
-        </ul>
-      </li>
-      <li>
-        <span class="font-medium"><?= __('register_fee_title') ?></span>
-        <ul class="list-disc pl-5 sm:pl-6">
-          <li><?= __('register_fee_full') ?></li>
-          <li><?= __('register_fee_discount') ?></li>
-        </ul>
-        <?= __('register_bank_title') ?>
-        <ul class="list-disc pl-5 sm:pl-6 mt-1 space-y-2">
-          <li><?= __('register_bank_holder') ?></li>
-          <li><?= __('register_bank_account') ?></li>
-          <li><?= __('register_bank_note') ?></li>
-        </ul>
-        <div class="mt-2 text-red-500 text-[15px] font-medium">
-          <?= __('register_fee_note') ?>
-        </div>
-      </li>
-    </ol>
-    <div class="mb-3">
-      <span class="block font-medium"><?= __('register_steps_title') ?></span>
-      <ul class="list-decimal pl-5 sm:pl-6 mt-1 space-y-3">
-        <li><?= __('register_step1') ?></li>
-        <li><?= __('register_step2') ?></li>
-        <li><?= __('register_step3') ?></li>
-        <li><?= __('register_step4') ?></li>
-      </ul>
-    </div>
-    <div class="mt-2 text-sm text-gray-500 text-center">
-      <?= __('register_support') ?>
-    </div>
-  </div>
-</div>
-
-<script>
-document.getElementById('open-register-modal').onclick = function(e) {
-  e.preventDefault();
-  document.getElementById('register-modal').classList.remove('hidden');
-};
-document.getElementById('close-register-modal').onclick = function() {
-  document.getElementById('register-modal').classList.add('hidden');
-};
-document.getElementById('register-modal').onclick = function(e) {
-  if (e.target === this) this.classList.add('hidden');
-};
-</script>
 
 <?php include 'footer.php'; ?>

--- a/views/register.php
+++ b/views/register.php
@@ -18,6 +18,10 @@
         <input type="text" name="email" class="w-full px-3 py-2 border border-mint rounded-lg bg-gray-50 text-gray-800 focus:outline-none focus:border-mint-dark focus:bg-white transition" required>
       </div>
       <div>
+        <label class="block text-sm font-medium text-mint-text mb-1"><?= __('phone_label') ?></label>
+        <input type="tel" name="phone" class="w-full px-3 py-2 border border-mint rounded-lg bg-gray-50 text-gray-800 focus:outline-none focus:border-mint-dark focus:bg-white transition" required>
+      </div>
+      <div>
         <label class="block text-sm font-medium text-mint-text mb-1"><?= __('password_label') ?></label>
         <input type="password" name="password" class="w-full px-3 py-2 border border-mint rounded-lg bg-gray-50 text-gray-800 focus:outline-none focus:border-mint-dark focus:bg-white transition" required>
       </div>

--- a/views/self_register.php
+++ b/views/self_register.php
@@ -3,7 +3,7 @@
   <div class="w-full max-w-md bg-white/90 rounded-xl shadow-lg p-8">
     <h2 class="text-center text-2xl font-bold mb-6">Đăng ký tài khoản</h2>
     <?php if ($done): ?>
-      <div class="text-green-600 text-sm mb-4">Vui lòng kiểm tra email để xác thực tài khoản.</div>
+      <div class="text-green-600 text-sm mb-4">Đăng ký thành công. Bạn có thể đăng nhập.</div>
     <?php endif; ?>
     <?php if (!empty($err)): ?>
       <div class="text-red-600 text-sm mb-4"><?= htmlspecialchars($err) ?></div>
@@ -19,20 +19,13 @@
         <input type="email" name="email" required class="w-full px-4 py-2 border rounded-lg" />
       </div>
       <div>
+        <label class="block mb-1">Số điện thoại</label>
+        <input type="tel" name="phone" required class="w-full px-4 py-2 border rounded-lg" />
+      </div>
+      <div>
         <label class="block mb-1">Mật khẩu</label>
         <input type="password" name="password" required class="w-full px-4 py-2 border rounded-lg" />
       </div>
-      <?php $siteKey = $_ENV['RECAPTCHA_SITE_KEY'] ?? ''; $version = $_ENV['RECAPTCHA_VERSION'] ?? 'v2'; ?>
-      <?php if ($version === 'v3'): ?>
-        <input type="hidden" name="recaptcha_token" id="recaptcha_token">
-        <script src="https://www.google.com/recaptcha/api.js?render=<?= $siteKey ?>"></script>
-        <script>
-        grecaptcha.ready(function(){grecaptcha.execute('<?= $siteKey ?>',{action:'register'}).then(function(token){document.getElementById('recaptcha_token').value = token;});});
-        </script>
-      <?php else: ?>
-        <div class="g-recaptcha" data-sitekey="<?= $siteKey ?>"></div>
-        <script src="https://www.google.com/recaptcha/api.js" async defer></script>
-      <?php endif; ?>
       <button class="w-full bg-[#9dcfc3] text-[#285F57] font-semibold py-2 rounded-lg">Đăng ký</button>
     </form>
   </div>

--- a/vnpay_ipn.php
+++ b/vnpay_ipn.php
@@ -36,13 +36,13 @@ if ($checkHash === $secureHash) {
         $order = $orderModel->markPaid($orderId);
         if ($order && $order['status'] === 'paid') {
             $userModel = new UserModel($db);
-            $user = $userModel->findByEmail($order['email']);
+            $user = $userModel->findByEmailOrPhone($order['email']);
             if ($user) {
                 $stmt = $db->prepare('UPDATE users SET remaining = remaining + ? WHERE id = ?');
                 $stmt->execute([$order['sessions'], $user['id']]);
             } else {
                 $pass = bin2hex(random_bytes(4));
-                $userModel->createStudent($order['full_name'], $order['email'], $pass, $order['sessions']);
+                $userModel->createStudent($order['full_name'], $order['email'], $order['phone'] ?? '', $pass, $order['sessions']);
             }
             // send email
             $body = 'Cảm ơn bạn đã đăng ký lớp học. Đăng nhập tại ' . ($_ENV['APP_URL'] ?? '') . '/login.php';


### PR DESCRIPTION
## Summary
- Allow login using email or phone without requiring email verification
- Remove reCAPTCHA/email verification from registration and collect phone numbers
- Link login page to registration page

## Testing
- `php -l models/UserModel.php controllers/LoginController.php controllers/SelfRegisterController.php controllers/RegisterController.php vnpay_ipn.php`
- `php -l views/self_register.php views/login.php views/register.php lang/vi.php lang/en.php lang/uk.php`
- `composer install` *(fails: Required package "phpmailer/phpmailer" is not present in the lock file)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_68915e0cddec83269b0a79e9b0146b2b