### PR TITLE
Simplify login to match minimal users table

### DIFF
--- a/controllers/LoginController.php
+++ b/controllers/LoginController.php
@@ -15,10 +15,10 @@ class LoginController {
         $err = "";
         if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             csrf_check($_POST['csrf_token'] ?? null);
-            $identifier = $_POST['email'] ?? '';
-            $pass       = $_POST['password'] ?? '';
-            $model      = new UserModel($this->db);
-            $user       = $model->findByEmailOrPhone($identifier);
+            $email = $_POST['email'] ?? '';
+            $pass  = $_POST['password'] ?? '';
+            $model = new UserModel($this->db);
+            $user  = $model->findByEmail($email);
             if ($user && password_verify($pass, $user['password'])) {
                 session_regenerate_id(true);
                 $_SESSION['uid']  = $user['id'];

--- a/controllers/RegisterController.php
+++ b/controllers/RegisterController.php
@@ -19,19 +19,17 @@ class RegisterController {
         $err = "";
         if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             csrf_check($_POST['csrf_token'] ?? null);
-            $name   = trim($_POST['full_name'] ?? '');
-            $email  = trim($_POST['email'] ?? '');
-            $phone  = trim($_POST['phone'] ?? '');
-            $pass   = $_POST['password'] ?? '';
-            $remain = intval($_POST['remaining'] ?? 0);
-            if (!$name || !$email || !$phone || !$pass) {
+            $name  = trim($_POST['full_name'] ?? '');
+            $email = trim($_POST['email'] ?? '');
+            $pass  = $_POST['password'] ?? '';
+            if (!$name || !$email || !$pass) {
                 $err = __('err_required_fields');
             } else {
                 $model = new UserModel($this->db);
-                if ($model->findByEmailOrPhone($email) || $model->findByEmailOrPhone($phone)) {
+                if ($model->findByEmail($email)) {
                     $err = __('err_email_exists');
                 } else {
-                    $model->createStudent($name, $email, $phone, $pass, $remain);
+                    $model->createStudent($name, $email, $pass);
                     header('Location: admin.php');
                     exit;
                 }

--- a/controllers/SelfRegisterController.php
+++ b/controllers/SelfRegisterController.php
@@ -18,16 +18,15 @@ class SelfRegisterController {
             csrf_check($_POST['csrf_token'] ?? null);
             $name  = trim($_POST['full_name'] ?? '');
             $email = trim($_POST['email'] ?? '');
-            $phone = trim($_POST['phone'] ?? '');
             $pass  = $_POST['password'] ?? '';
-            if (!$name || !$email || !$phone || !$pass) {
+            if (!$name || !$email || !$pass) {
                 $err = 'Vui lòng nhập đầy đủ thông tin';
             } else {
                 $model = new UserModel($this->db);
-                if ($model->findByEmailOrPhone($email) || $model->findByEmailOrPhone($phone)) {
-                    $err = 'Email hoặc số điện thoại đã được sử dụng';
+                if ($model->findByEmail($email)) {
+                    $err = 'Email đã được sử dụng';
                 } else {
-                    $model->createStudent($name, $email, $phone, $pass);
+                    $model->createStudent($name, $email, $pass);
                     $done = true;
                 }
             }

--- a/models/UserModel.php
+++ b/models/UserModel.php
@@ -10,9 +10,9 @@ class UserModel {
         $this->db = $db;
     }
 
-    public function findByEmailOrPhone(string $identifier): ?array {
-        $stmt = $this->db->prepare('SELECT * FROM users WHERE email = ? OR phone = ?');
-        $stmt->execute([$identifier, $identifier]);
+    public function findByEmail(string $email): ?array {
+        $stmt = $this->db->prepare('SELECT * FROM users WHERE email = ?');
+        $stmt->execute([$email]);
         $row = $stmt->fetch(PDO::FETCH_ASSOC);
         return $row ?: null;
     }
@@ -20,15 +20,13 @@ class UserModel {
     public function createStudent(
         string $name,
         string $email,
-        string $phone,
-        string $pass,
-        int $remain = 0
+        string $pass
     ): void {
         $hash = password_hash($pass, PASSWORD_DEFAULT);
-        $sql = "INSERT INTO users (role,full_name,email,phone,password,remaining,verified,verify_token) "
-             . "VALUES ('student', ?, ?, ?, ?, ?, 1, NULL)";
+        $sql = "INSERT INTO users (role, full_name, email, password) "
+             . "VALUES ('student', ?, ?, ?)";
         $stmt = $this->db->prepare($sql);
-        $stmt->execute([$name, $email, $phone, $hash, $remain]);
+        $stmt->execute([$name, $email, $hash]);
     }
 }
 

--- a/views/register.php
+++ b/views/register.php
@@ -18,16 +18,8 @@
         <input type="text" name="email" class="w-full px-3 py-2 border border-mint rounded-lg bg-gray-50 text-gray-800 focus:outline-none focus:border-mint-dark focus:bg-white transition" required>
       </div>
       <div>
-        <label class="block text-sm font-medium text-mint-text mb-1"><?= __('phone_label') ?></label>
-        <input type="tel" name="phone" class="w-full px-3 py-2 border border-mint rounded-lg bg-gray-50 text-gray-800 focus:outline-none focus:border-mint-dark focus:bg-white transition" required>
-      </div>
-      <div>
         <label class="block text-sm font-medium text-mint-text mb-1"><?= __('password_label') ?></label>
         <input type="password" name="password" class="w-full px-3 py-2 border border-mint rounded-lg bg-gray-50 text-gray-800 focus:outline-none focus:border-mint-dark focus:bg-white transition" required>
-      </div>
-      <div>
-        <label class="block text-sm font-medium text-mint-text mb-1"><?= __('initial_sessions') ?></label>
-        <input type="number" name="remaining" min="0" value="20" class="w-full px-3 py-2 border border-mint rounded-lg bg-gray-50 text-gray-800 focus:outline-none focus:border-mint-dark focus:bg-white transition">
       </div>
       <div class="flex justify-between items-center mt-6 gap-2">
         <a class="rounded-lg border border-mint text-mint-text px-4 py-2 text-sm font-medium hover:bg-mint hover:text-white transition text-center" href="admin.php">

--- a/views/self_register.php
+++ b/views/self_register.php
@@ -19,10 +19,6 @@
         <input type="email" name="email" required class="w-full px-4 py-2 border rounded-lg" />
       </div>
       <div>
-        <label class="block mb-1">Số điện thoại</label>
-        <input type="tel" name="phone" required class="w-full px-4 py-2 border rounded-lg" />
-      </div>
-      <div>
         <label class="block mb-1">Mật khẩu</label>
         <input type="password" name="password" required class="w-full px-4 py-2 border rounded-lg" />
       </div>

--- a/vnpay_ipn.php
+++ b/vnpay_ipn.php
@@ -36,13 +36,10 @@ if ($checkHash === $secureHash) {
         $order = $orderModel->markPaid($orderId);
         if ($order && $order['status'] === 'paid') {
             $userModel = new UserModel($db);
-            $user = $userModel->findByEmailOrPhone($order['email']);
-            if ($user) {
-                $stmt = $db->prepare('UPDATE users SET remaining = remaining + ? WHERE id = ?');
-                $stmt->execute([$order['sessions'], $user['id']]);
-            } else {
+            $user = $userModel->findByEmail($order['email']);
+            if (!$user) {
                 $pass = bin2hex(random_bytes(4));
-                $userModel->createStudent($order['full_name'], $order['email'], $order['phone'] ?? '', $pass, $order['sessions']);
+                $userModel->createStudent($order['full_name'], $order['email'], $pass);
             }
             // send email
             $body = 'Cảm ơn bạn đã đăng ký lớp học. Đăng nhập tại ' . ($_ENV['APP_URL'] ?? '') . '/login.php';


### PR DESCRIPTION
## Summary
- authenticate users solely by email and password
- drop phone/remaining fields from user creation flows
- adjust payment callback to create accounts by email only

## Testing
- `vendor/bin/phpunit tests` *(fails: No such file or directory)*
- `phpunit tests` *(command not found)*
- `apt-get update` *(403 Forbidden; repository not signed)*
- `wget -O phpunit.phar https://phar.phpunit.de/phpunit-9.phar` *(Proxy tunneling failed: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_6891657168e883269a168d768f1c1820