### PR TITLE
feat: update login flow and payment info

### DIFF
--- a/controllers/LoginController.php
+++ b/controllers/LoginController.php
@@ -15,15 +15,23 @@ class LoginController {
         $err = "";
         if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             csrf_check($_POST['csrf_token'] ?? null);
-            $email = $_POST['email'] ?? '';
+            $phone = $_POST['phone'] ?? '';
             $pass  = $_POST['password'] ?? '';
             $model = new UserModel($this->db);
-            $user  = $model->findByEmail($email);
+            $user  = $model->findByEmail($phone);
             if ($user && password_verify($pass, $user['password'])) {
                 session_regenerate_id(true);
                 $_SESSION['uid']  = $user['id'];
                 $_SESSION['role'] = $user['role'];
-                header('Location: ' . ($user['role'] === 'admin' ? 'admin.php' : 'dashboard.php'));
+                if ($user['role'] === 'admin') {
+                    header('Location: admin.php');
+                } else {
+                    if (($user['remaining'] ?? 0) > 0) {
+                        header('Location: dashboard.php');
+                    } else {
+                        header('Location: welcome.php');
+                    }
+                }
                 exit;
             }
             $err = __('login_error');

--- a/controllers/SelfRegisterController.php
+++ b/controllers/SelfRegisterController.php
@@ -13,21 +13,21 @@ class SelfRegisterController {
 
     public function handle(): void {
         $err = "";
-        $done = false;
         if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             csrf_check($_POST['csrf_token'] ?? null);
             $name  = trim($_POST['full_name'] ?? '');
-            $email = trim($_POST['email'] ?? '');
+            $phone = trim($_POST['phone'] ?? '');
             $pass  = $_POST['password'] ?? '';
-            if (!$name || !$email || !$pass) {
+            if (!$name || !$phone || !$pass) {
                 $err = 'Vui lòng nhập đầy đủ thông tin';
             } else {
                 $model = new UserModel($this->db);
-                if ($model->findByEmail($email)) {
-                    $err = 'Email đã được sử dụng';
+                if ($model->findByEmail($phone)) {
+                    $err = 'Số điện thoại đã được sử dụng';
                 } else {
-                    $model->createStudent($name, $email, $pass);
-                    $done = true;
+                    $model->createStudent($name, $phone, $pass);
+                    header('Location: welcome.php');
+                    exit;
                 }
             }
         }

--- a/dashboard.php
+++ b/dashboard.php
@@ -11,6 +11,10 @@ $stmt = $db->prepare("SELECT full_name, remaining FROM users WHERE id=?");
 $stmt->execute([$uid]);
 $user = $stmt->fetch(PDO::FETCH_ASSOC);
 $remain = $user['remaining'] ?? 0;
+if ($remain <= 0) {
+    header('Location: welcome.php');
+    exit;
+}
 
 // Lấy lịch sử
 $stmt = $db->prepare("SELECT session, created_at FROM sessions WHERE user_id=? ORDER BY created_at DESC LIMIT 5");
@@ -40,7 +44,6 @@ require 'header.php';
     <div class="text-center mb-6 text-lg font-semibold text-green-700 flex flex-col items-center">
       🌿 <span><?= sprintf(__('remaining_sessions'), $remain) ?></span>
     </div>
-    <?php if ($remain > 0): ?>
     <div class="flex flex-col md:flex-row gap-4 mb-6">
       <div class="flex-1 bg-white/90 rounded-xl shadow p-4 flex flex-col items-center border border-mint/30">
         <div class="mb-2 font-semibold text-base text-mint-text"><?= __('morning_class') ?> <span class="text-gray-400 text-sm">06:00-06:40</span></div>
@@ -67,16 +70,6 @@ require 'header.php';
         </a>
       </div>
     </div>
-    <?php else: ?>
-    <div class="flex flex-col md:flex-row gap-4 mb-6">
-      <a href="checkout.php?plan=20" class="flex-1 rounded-xl bg-gradient-to-tr from-[#b6f0de] to-[#9dcfc3] text-[#285F57] font-bold py-3 text-center shadow-lg hover:scale-[1.03] hover:shadow-xl transition focus:ring-2 focus:ring-mint-dark outline-none">
-        <?= __('buy_plan20') ?>
-      </a>
-      <a href="bill.php" class="flex-1 rounded-xl bg-gradient-to-tr from-[#b6f0de] to-[#9dcfc3] text-[#285F57] font-bold py-3 text-center shadow-lg hover:scale-[1.03] hover:shadow-xl transition focus:ring-2 focus:ring-mint-dark outline-none">
-        <?= __('bill_button') ?>
-      </a>
-    </div>
-    <?php endif; ?>
     <h5 class="text-center text-base font-semibold text-mint-text mt-2 mb-3"><?= __('recent_history') ?></h5>
     <div class="overflow-x-auto">
       <table class="w-full text-sm bg-white border border-gray-100 rounded-lg">

--- a/lang/en.php
+++ b/lang/en.php
@@ -8,6 +8,7 @@ return [
     'password_label' => 'Password',
     'email_placeholder' => 'Enter email or phone...',
     'password_placeholder' => 'Enter password...',
+    'phone_placeholder' => 'Enter phone number...',
     'no_account' => "Don't have an account?",
     'register_link' => 'Sign up',
     'login_error' => 'Incorrect email or password!',

--- a/lang/uk.php
+++ b/lang/uk.php
@@ -8,6 +8,7 @@ return [
     'password_label' => 'Пароль',
     'email_placeholder' => 'Введіть email або телефон...',
     'password_placeholder' => 'Введіть пароль...',
+    'phone_placeholder' => 'Введіть номер телефону...',
     'no_account' => 'Немає акаунта?',
     'register_link' => 'Зареєструватися',
     'login_error' => 'Невірний email або пароль!',

--- a/lang/vi.php
+++ b/lang/vi.php
@@ -8,6 +8,7 @@ return [
     'password_label' => 'Mật khẩu',
     'email_placeholder' => 'Nhập email hoặc SĐT...',
     'password_placeholder' => 'Nhập mật khẩu...',
+    'phone_placeholder' => 'Nhập số điện thoại...',
     'no_account' => 'Chưa có tài khoản?',
     'register_link' => 'Đăng ký',
     'login_error' => 'Sai tài khoản hoặc mật khẩu!',

--- a/payment_info.php
+++ b/payment_info.php
@@ -1,0 +1,25 @@
+<?php
+$pageTitle = 'Thông tin thanh toán';
+include 'header.php';
+?>
+<main class="min-h-[75vh] flex items-center justify-center py-12">
+  <div class="w-full max-w-2xl bg-white/90 rounded-xl shadow-lg p-8 space-y-6">
+    <h2 class="text-2xl font-bold text-center">Nạp buổi học</h2>
+    <section class="space-y-2">
+      <h3 class="text-lg font-semibold">Quy định tham gia lớp học</h3>
+      <p>Học viên cần tuân thủ nội quy lớp và giữ thái độ tôn trọng trong suốt buổi thiền.</p>
+    </section>
+    <section class="space-y-2">
+      <h3 class="text-lg font-semibold">Thông tin chuyển khoản</h3>
+      <p>Chủ TK: Trần Thị Mai Ly</p>
+      <p>STK: 0371000429939 (Vietcombank - CN Hồ Chí Minh)</p>
+    </section>
+    <section class="space-y-2">
+      <h3 class="text-lg font-semibold">Hướng dẫn</h3>
+      <p>Sau khi chuyển khoản, vui lòng gửi ảnh biên lai kèm tên và số điện thoại cho admin qua Zalo hoặc email.</p>
+      <p>Sau khi admin xác nhận, hệ thống sẽ cập nhật số buổi học vào tài khoản của bạn.</p>
+    </section>
+    <p class="text-sm text-gray-500">Hiện chưa hỗ trợ VNPay, sẽ cập nhật sau.</p>
+  </div>
+</main>
+<?php include 'footer.php'; ?>

--- a/views/login.php
+++ b/views/login.php
@@ -8,10 +8,10 @@
     <form method="post" autocomplete="off" class="space-y-5">
       <input type="hidden" name="csrf_token" value="<?= $_SESSION['csrf_token']; ?>">
       <div>
-        <label class="block text-sm font-medium text-[#285F57] mb-1"><?= __('email_label') ?></label>
-        <input name="email" type="text" required autofocus
+        <label class="block text-sm font-medium text-[#285F57] mb-1"><?= __('phone_label') ?></label>
+        <input name="phone" type="text" required autofocus
           class="w-full px-4 py-2 border-2 border-[#9dcfc3] rounded-lg bg-gray-50 text-[#374151] focus:outline-none focus:border-[#76a89e] focus:bg-white transition"
-          placeholder="<?= __('email_placeholder') ?>" />
+          placeholder="<?= __('phone_placeholder') ?>" />
       </div>
       <div>
         <label class="block text-sm font-medium text-[#285F57] mb-1"><?= __('password_label') ?></label>

--- a/views/self_register.php
+++ b/views/self_register.php
@@ -2,9 +2,6 @@
 <main class="min-h-[75vh] flex items-center justify-center py-12">
   <div class="w-full max-w-md bg-white/90 rounded-xl shadow-lg p-8">
     <h2 class="text-center text-2xl font-bold mb-6">Đăng ký tài khoản</h2>
-    <?php if ($done): ?>
-      <div class="text-green-600 text-sm mb-4">Đăng ký thành công. Bạn có thể đăng nhập.</div>
-    <?php endif; ?>
     <?php if (!empty($err)): ?>
       <div class="text-red-600 text-sm mb-4"><?= htmlspecialchars($err) ?></div>
     <?php endif; ?>
@@ -15,8 +12,8 @@
         <input type="text" name="full_name" required class="w-full px-4 py-2 border rounded-lg" />
       </div>
       <div>
-        <label class="block mb-1">Email</label>
-        <input type="email" name="email" required class="w-full px-4 py-2 border rounded-lg" />
+        <label class="block mb-1">Số điện thoại</label>
+        <input type="text" name="phone" required class="w-full px-4 py-2 border rounded-lg" />
       </div>
       <div>
         <label class="block mb-1">Mật khẩu</label>

--- a/welcome.php
+++ b/welcome.php
@@ -1,0 +1,11 @@
+<?php
+$pageTitle = 'Chào mừng';
+include 'header.php';
+?>
+<main class="min-h-[75vh] flex items-center justify-center py-12">
+  <div class="w-full max-w-md bg-white/90 rounded-xl shadow-lg p-8 text-center space-y-6">
+    <p class="text-lg">Chào mừng bạn đến với lớp thiền NamaHealing. Vui lòng mua thêm buổi để tham gia và sớm chữa lành.</p>
+    <a href="payment_info.php" class="inline-block px-6 py-3 bg-[#9dcfc3] text-[#285F57] font-semibold rounded-lg">Thông tin thanh toán</a>
+  </div>
+</main>
+<?php include 'footer.php'; ?>


### PR DESCRIPTION
## Summary
- require phone number for self-registration and redirect new students to welcome screen
- log in by phone; redirect to dashboard when sessions remain, otherwise to welcome screen
- add welcome and payment info pages with bank transfer instructions

## Testing
- `php -l controllers/LoginController.php controllers/SelfRegisterController.php dashboard.php lang/en.php lang/uk.php lang/vi.php views/login.php views/self_register.php welcome.php payment_info.php`
- `phpunit --colors=always` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68916f1269c08326b31c0780d06bed2c