### PR TITLE
refactor: rely on global session init

### DIFF
--- a/articles.php
+++ b/articles.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . '/i18n.php';
 $pageTitle = 'Bài viết';
 $metaDescription = 'Tổng hợp các bài viết chia sẻ kiến thức thiền định, yoga và tự chữa lành từ NamaHealing.';
 
@@ -11,8 +12,8 @@ if (file_exists($file)) {
         $articles = $data;
     }
 }
+include 'header.php';
 ?>
-<?php include 'header.php'; ?>
 <main class="max-w-3xl mx-auto px-4 py-6">
   <h1 class="text-2xl font-semibold mb-6">Bài viết</h1>
   <?php foreach ($articles as $article): ?>

--- a/footer.php
+++ b/footer.php
@@ -1,5 +1,4 @@
 <?php
-if (session_status() === PHP_SESSION_NONE) session_start();
 require_once __DIR__ . '/i18n.php';
 $isChatbotPage = basename($_SERVER['PHP_SELF']) === 'chatbot.php';
 ?>

--- a/header.php
+++ b/header.php
@@ -1,5 +1,4 @@
 <?php
-if (session_status() === PHP_SESSION_NONE) session_start();
 require_once __DIR__ . '/i18n.php';
 ?>
 <!DOCTYPE html>

--- a/payment_info.php
+++ b/payment_info.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . '/i18n.php';
 $pageTitle = 'Thông tin thanh toán';
 include 'header.php';
 ?>

--- a/videos.php
+++ b/videos.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . '/i18n.php';
 $pageTitle = 'Video';
 $metaDescription = 'Video hướng dẫn thiền, yoga và chữa lành từ NamaHealing giúp bạn thư giãn, cân bằng cuộc sống.';
 
@@ -11,8 +12,8 @@ if (file_exists($file)) {
         $videos = $data;
     }
 }
+include 'header.php';
 ?>
-<?php include 'header.php'; ?>
 <main class="max-w-6xl mx-auto px-4 py-8">
   <h1 class="text-2xl font-semibold mb-8">Video</h1>
   <div class="grid gap-8 sm:grid-cols-2 lg:grid-cols-3">

--- a/welcome.php
+++ b/welcome.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . '/i18n.php';
 $pageTitle = 'Chào mừng';
 include 'header.php';
 ?>


### PR DESCRIPTION
## Summary
- remove direct session initialization in header and footer
- initialize sessions in standalone pages before including layout files

## Testing
- `curl -I http://localhost:8000/videos.php`
- `curl -I http://localhost:8000/articles.php`
- `curl -I http://localhost:8000/payment_info.php`
- `curl -I http://localhost:8000/welcome.php`
- `php -l header.php footer.php welcome.php videos.php articles.php payment_info.php`


------
https://chatgpt.com/codex/tasks/task_b_6891826e51dc8326b77507cef9181714