### PR TITLE
Clarify identifier lookup across user operations

### DIFF
--- a/controllers/LoginController.php
+++ b/controllers/LoginController.php
@@ -16,9 +16,10 @@ class LoginController {
         if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             csrf_check($_POST['csrf_token'] ?? null);
             $phone = $_POST['phone'] ?? '';
+            // Phone or email identifier stored in users.email
             $pass  = $_POST['password'] ?? '';
             $model = new UserModel($this->db);
-            $user  = $model->findByEmail($phone);
+            $user  = $model->findByIdentifier($phone);
             if ($user && password_verify($pass, $user['password'])) {
                 session_regenerate_id(true);
                 $_SESSION['uid']  = $user['id'];

--- a/controllers/RegisterController.php
+++ b/controllers/RegisterController.php
@@ -20,16 +20,16 @@ class RegisterController {
         if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             csrf_check($_POST['csrf_token'] ?? null);
             $name  = trim($_POST['full_name'] ?? '');
-            $email = trim($_POST['email'] ?? '');
+            $email = trim($_POST['email'] ?? ''); // email or phone
             $pass  = $_POST['password'] ?? '';
             if (!$name || !$email || !$pass) {
                 $err = __('err_required_fields');
             } else {
                 $model = new UserModel($this->db);
-                if ($model->findByEmail($email)) {
+                if ($model->findByIdentifier($email)) {
                     $err = __('err_email_exists');
                 } else {
-                    $model->createStudent($name, $email, $pass);
+                    $model->createStudent($name, $email, $pass); // identifier stored in email column
                     header('Location: admin.php');
                     exit;
                 }

--- a/controllers/SelfRegisterController.php
+++ b/controllers/SelfRegisterController.php
@@ -16,16 +16,16 @@ class SelfRegisterController {
         if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             csrf_check($_POST['csrf_token'] ?? null);
             $name  = trim($_POST['full_name'] ?? '');
-            $phone = trim($_POST['phone'] ?? '');
+            $phone = trim($_POST['phone'] ?? ''); // stored in users.email
             $pass  = $_POST['password'] ?? '';
             if (!$name || !$phone || !$pass) {
                 $err = 'Vui lòng nhập đầy đủ thông tin';
             } else {
                 $model = new UserModel($this->db);
-                if ($model->findByEmail($phone)) {
+                if ($model->findByIdentifier($phone)) {
                     $err = 'Số điện thoại đã được sử dụng';
                 } else {
-                    $model->createStudent($name, $phone, $pass);
+                    $model->createStudent($name, $phone, $pass); // phone stored in email column
                     header('Location: welcome.php');
                     exit;
                 }

--- a/models/UserModel.php
+++ b/models/UserModel.php
@@ -10,23 +10,24 @@ class UserModel {
         $this->db = $db;
     }
 
-    public function findByEmail(string $email): ?array {
+    public function findByIdentifier(string $identifier): ?array {
         $stmt = $this->db->prepare('SELECT * FROM users WHERE email = ?');
-        $stmt->execute([$email]);
+        $stmt->execute([$identifier]);
         $row = $stmt->fetch(PDO::FETCH_ASSOC);
         return $row ?: null;
     }
 
     public function createStudent(
         string $name,
-        string $email,
+        string $identifier,
         string $pass
     ): void {
         $hash = password_hash($pass, PASSWORD_DEFAULT);
+        // The identifier (email or phone) is stored in the `email` column
         $sql = "INSERT INTO users (role, full_name, email, password) "
              . "VALUES ('student', ?, ?, ?)";
         $stmt = $this->db->prepare($sql);
-        $stmt->execute([$name, $email, $hash]);
+        $stmt->execute([$name, $identifier, $hash]);
     }
 }
 

--- a/vnpay_ipn.php
+++ b/vnpay_ipn.php
@@ -36,10 +36,10 @@ if ($checkHash === $secureHash) {
         $order = $orderModel->markPaid($orderId);
         if ($order && $order['status'] === 'paid') {
             $userModel = new UserModel($db);
-            $user = $userModel->findByEmail($order['email']);
+            $user = $userModel->findByIdentifier($order['email']); // email or phone
             if (!$user) {
                 $pass = bin2hex(random_bytes(4));
-                $userModel->createStudent($order['full_name'], $order['email'], $pass);
+                $userModel->createStudent($order['full_name'], $order['email'], $pass); // identifier stored in email column
             }
             // send email
             $body = 'Cảm ơn bạn đã đăng ký lớp học. Đăng nhập tại ' . ($_ENV['APP_URL'] ?? '') . '/login.php';


### PR DESCRIPTION
## Summary
- replace `findByEmail` with generic `findByIdentifier` in `UserModel`
- adjust login and registration flows to use the new method and clearly pass phone/email identifiers
- document that identifiers (email or phone) are stored in the `users.email` column and update related scripts

## Testing
- `php -l models/UserModel.php controllers/LoginController.php controllers/SelfRegisterController.php controllers/RegisterController.php vnpay_ipn.php`
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `composer install` *(fails: Required package "phpmailer/phpmailer" is not present in the lock file)*
- `composer update` *(fails: curl error 56 while downloading packages)*

------
https://chatgpt.com/codex/tasks/task_b_6891827888648326a86185980f45d08b