### PR TITLE
Use POST with CSRF when joining sessions

### DIFF
--- a/dashboard.php
+++ b/dashboard.php
@@ -45,30 +45,38 @@ require 'header.php';
       🌿 <span><?= sprintf(__('remaining_sessions'), $remain) ?></span>
     </div>
     <div class="flex flex-col md:flex-row gap-4 mb-6">
-      <div class="flex-1 bg-white/90 rounded-xl shadow p-4 flex flex-col items-center border border-mint/30">
-        <div class="mb-2 font-semibold text-base text-mint-text"><?= __('morning_class') ?> <span class="text-gray-400 text-sm">06:00-06:40</span></div>
-        <a href="join.php?s=morning"
-           class="w-full rounded-xl bg-gradient-to-tr from-[#b6f0de] to-[#9dcfc3] text-[#285F57] font-bold py-2 text-center mt-3 shadow-lg hover:scale-[1.03] hover:shadow-xl transition
-                  focus:ring-2 focus:ring-mint-dark outline-none
-                  disabled:opacity-50 disabled:pointer-events-none"
-           <?php
-               if (!$remain || (!$has_history && is_morning_time())) echo 'disabled';
-           ?>>
-           <?= __('join_morning') ?>
-        </a>
-      </div>
-      <div class="flex-1 bg-white/90 rounded-xl shadow p-4 flex flex-col items-center border border-mint/30">
-        <div class="mb-2 font-semibold text-base text-mint-text"><?= __('evening_class') ?> <span class="text-gray-400 text-sm">20:45-21:25</span></div>
-        <a href="join.php?s=evening"
-           class="w-full rounded-xl bg-gradient-to-tr from-[#b6f0de] to-[#9dcfc3] text-[#285F57] font-bold py-2 text-center mt-3 shadow-lg hover:scale-[1.03] hover:shadow-xl transition
-                  focus:ring-2 focus:ring-mint-dark outline-none
-                  disabled:opacity-50 disabled:pointer-events-none"
-           <?php
-               if (!$remain || (!$has_history && is_evening_time())) echo 'disabled';
-           ?>>
-           <?= __('join_evening') ?>
-        </a>
-      </div>
+        <div class="flex-1 bg-white/90 rounded-xl shadow p-4 flex flex-col items-center border border-mint/30">
+          <div class="mb-2 font-semibold text-base text-mint-text"><?= __('morning_class') ?> <span class="text-gray-400 text-sm">06:00-06:40</span></div>
+          <form method="post" action="join.php" class="w-full">
+            <input type="hidden" name="csrf_token" value="<?= $_SESSION['csrf_token']; ?>">
+            <input type="hidden" name="session" value="morning">
+            <button type="submit"
+               class="w-full rounded-xl bg-gradient-to-tr from-[#b6f0de] to-[#9dcfc3] text-[#285F57] font-bold py-2 text-center mt-3 shadow-lg hover:scale-[1.03] hover:shadow-xl transition
+                      focus:ring-2 focus:ring-mint-dark outline-none
+                      disabled:opacity-50 disabled:pointer-events-none"
+               <?php
+                   if (!$remain || (!$has_history && is_morning_time())) echo 'disabled';
+               ?>>
+               <?= __('join_morning') ?>
+            </button>
+          </form>
+        </div>
+        <div class="flex-1 bg-white/90 rounded-xl shadow p-4 flex flex-col items-center border border-mint/30">
+          <div class="mb-2 font-semibold text-base text-mint-text"><?= __('evening_class') ?> <span class="text-gray-400 text-sm">20:45-21:25</span></div>
+          <form method="post" action="join.php" class="w-full">
+            <input type="hidden" name="csrf_token" value="<?= $_SESSION['csrf_token']; ?>">
+            <input type="hidden" name="session" value="evening">
+            <button type="submit"
+               class="w-full rounded-xl bg-gradient-to-tr from-[#b6f0de] to-[#9dcfc3] text-[#285F57] font-bold py-2 text-center mt-3 shadow-lg hover:scale-[1.03] hover:shadow-xl transition
+                      focus:ring-2 focus:ring-mint-dark outline-none
+                      disabled:opacity-50 disabled:pointer-events-none"
+               <?php
+                   if (!$remain || (!$has_history && is_evening_time())) echo 'disabled';
+               ?>>
+               <?= __('join_evening') ?>
+            </button>
+          </form>
+        </div>
     </div>
     <h5 class="text-center text-base font-semibold text-mint-text mt-2 mb-3"><?= __('recent_history') ?></h5>
     <div class="overflow-x-auto">

--- a/join.php
+++ b/join.php
@@ -5,8 +5,15 @@ if (!isset($_SESSION['uid']) || $_SESSION['role'] !== 'student') {
     header('Location: login.php'); exit;
 }
 
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    header('Location: dashboard.php');
+    exit;
+}
+
+csrf_check($_POST['csrf_token'] ?? null);
+
 $uid = $_SESSION['uid'];
-$session = ($_GET['s'] ?? 'morning');
+$session = ($_POST['session'] ?? 'morning');
 if (!in_array($session, ['morning', 'evening'])) $session = 'morning';
 
 // Kiểm tra số buổi còn lại


### PR DESCRIPTION
## Summary
- Replace join links on the dashboard with POST forms that include CSRF tokens and session identifiers.
- Update join.php to handle POST requests, validate CSRF tokens, and redirect on invalid methods.

## Testing
- `php -l dashboard.php`
- `php -l join.php`
- `phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6891825c67808326a53486eff2c94df2