### PR TITLE
Fix teacher dashboard authentication redirect

### DIFF
--- a/journal.php
+++ b/journal.php
@@ -1,5 +1,4 @@
 <?php
-define('REQUIRE_LOGIN', true);
 require 'config.php';
 if (($_SESSION['role'] ?? '') !== 'teacher') {
     header('Location: teacher_login.php');

--- a/reply_journal.php
+++ b/reply_journal.php
@@ -1,5 +1,4 @@
 <?php
-define('REQUIRE_LOGIN', true);
 require 'config.php';
 if (($_SESSION['role'] ?? '') !== 'teacher') {
     header('Location: teacher_login.php');
@@ -19,3 +18,4 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     exit;
 }
 header('Location: teacher_dashboard.php');
+exit;

--- a/teacher_dashboard.php
+++ b/teacher_dashboard.php
@@ -1,5 +1,4 @@
 <?php
-define('REQUIRE_LOGIN', true);
 require 'config.php';
 if (($_SESSION['role'] ?? '') !== 'teacher') {
     header('Location: teacher_login.php');


### PR DESCRIPTION
## Summary
- Ensure teacher pages redirect unauthenticated access to `teacher_login.php`
- Add exit after reply redirect in `reply_journal.php` to stop script execution

## Testing
- `apt-get update` *(fails: The repository 'http://apt.llvm.org/noble llvm-toolchain-noble-20 InRelease' is not signed)*
- `composer require --dev phpunit/phpunit` *(fails: CONNECT tunnel failed, response 403)*
- `phpunit -c phpunit.xml` *(fails: command not found: phpunit)*


------
https://chatgpt.com/codex/tasks/task_b_6895ab1e777083268ff94aa55ea1fdc0