### PR TITLE
feat: add journal view for teachers

### DIFF
--- a/fetch_journals.php
+++ b/fetch_journals.php
@@ -1,0 +1,24 @@
+<?php
+define('REQUIRE_LOGIN', true);
+require 'config.php';
+
+if (($_SESSION['role'] ?? '') !== 'teacher') {
+    http_response_code(403);
+    exit;
+}
+
+header('Content-Type: application/json; charset=utf-8');
+$student_id = (int)($_GET['student_id'] ?? 0);
+if ($student_id <= 0) {
+    echo json_encode(['error' => 'invalid_id']);
+    exit;
+}
+
+try {
+    $stmt = $db->prepare('SELECT id, meditation_at, content, teacher_reply, replied_at FROM journals WHERE student_id = ? ORDER BY meditation_at ASC');
+    $stmt->execute([$student_id]);
+    $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+    echo json_encode(['journals' => $rows], JSON_UNESCAPED_UNICODE);
+} catch (Throwable $e) {
+    echo json_encode(['error' => 'db_error']);
+}

--- a/teacher_dashboard.php
+++ b/teacher_dashboard.php
@@ -12,20 +12,9 @@ if (($_SESSION['role'] ?? '') !== 'teacher') {
 }
 
 try {
-    $sql = "
-        SELECT 
-            u.id, u.full_name, u.email,
-            (SELECT COUNT(*) FROM sessions s WHERE s.user_id = u.id) AS session_count,
-            (SELECT MAX(j.meditation_at) FROM journals j WHERE j.student_id = u.id) AS latest_journal,
-            EXISTS(
-              SELECT 1 FROM journals j 
-              WHERE j.student_id = u.id AND j.seen_at IS NULL
-            ) AS has_unseen
-        FROM users u
-        WHERE u.role = 'student'
-        ORDER BY u.full_name
-    ";
-    $students = $pdo->query($sql)->fetchAll(PDO::FETCH_ASSOC);
+    $stmt = $pdo->prepare("\n        SELECT\n            u.id, u.full_name,\n            (SELECT COUNT(*) FROM sessions s WHERE s.user_id = u.id) AS session_count,\n            (SELECT MAX(j.meditation_at) FROM journals j WHERE j.student_id = u.id) AS latest_journal,\n            EXISTS(\n              SELECT 1 FROM journals j\n              WHERE j.student_id = u.id AND j.seen_at IS NULL\n            ) AS has_unseen\n        FROM users u\n        WHERE u.role = 'student'\n        ORDER BY u.full_name\n    ");
+    $stmt->execute();
+    $students = $stmt->fetchAll(PDO::FETCH_ASSOC);
 } catch (Throwable $e) {
     die('Lỗi truy vấn: ' . htmlspecialchars($e->getMessage()));
 }
@@ -40,26 +29,35 @@ require 'header.php';
       <thead class="bg-gray-100">
         <tr>
           <th class="p-2 text-left">Tên</th>
-          <th class="p-2 text-left">Email</th>
           <th class="p-2 text-left">Số buổi đã tham gia</th>
-          <th class="p-2 text-left">Nhật ký gần nhất</th>
+          <th class="p-2 text-left">Báo thiền hàng ngày</th>
+          <th class="p-2 text-left"></th>
         </tr>
       </thead>
       <tbody>
       <?php foreach ($students as $s): ?>
         <tr class="border-t">
           <td class="p-2">
-            <a href="journal.php?student_id=<?= (int)$s['id'] ?>" class="text-blue-600 underline">
-              <?= htmlspecialchars($s['full_name'] ?? '') ?>
-            </a>
+            <?= htmlspecialchars($s['full_name'] ?? '') ?>
             <?php if (!empty($s['has_unseen'])): ?>
-              <span class="ml-2 bg-red-500 text-white text-xs px-2 py-1 rounded">Chưa xem</span>
+              <span class="ml-2 bg-red-500 text-white text-xs px-2 py-1 rounded badge-<?= (int)$s['id'] ?>">Chưa xem</span>
             <?php endif; ?>
           </td>
-          <td class="p-2"><?= htmlspecialchars($s['email'] ?? '') ?></td>
           <td class="p-2 text-center"><?= (int)($s['session_count'] ?? 0) ?></td>
           <td class="p-2">
             <?= !empty($s['latest_journal']) ? date('d/m/Y H:i', strtotime($s['latest_journal'])) : '-' ?>
+          </td>
+          <td class="p-2 text-center">
+            <button class="text-blue-600 underline toggle-journal" data-id="<?= (int)$s['id'] ?>">Xem báo thiền</button>
+          </td>
+        </tr>
+        <tr id="journal-row-<?= (int)$s['id'] ?>" class="border-t hidden">
+          <td colspan="4" class="p-4 bg-gray-50">
+            <div class="journal-messages space-y-2 mb-4"></div>
+            <form class="reply-form space-y-2" data-id="<?= (int)$s['id'] ?>">
+              <textarea class="w-full border px-3 py-2 rounded" required></textarea>
+              <button type="submit" class="bg-[#9dcfc3] text-white px-4 py-1 rounded">Gửi phản hồi</button>
+            </form>
           </td>
         </tr>
       <?php endforeach; ?>
@@ -67,4 +65,65 @@ require 'header.php';
     </table>
   </div>
 </main>
+<script>
+const csrfToken = '<?= $_SESSION['csrf_token']; ?>';
+
+function escapeHtml(str){
+  const map={'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#039;'};
+  return str.replace(/[&<>"']/g,m=>map[m]);
+}
+
+function renderJournals(container, journals){
+  container.innerHTML='';
+  journals.forEach(j=>{
+    const stu=document.createElement('div');
+    stu.className='text-left';
+    stu.innerHTML=`<div class="inline-block bg-gray-100 p-2 rounded"><div class="text-xs text-gray-500">${j.meditation_at}</div><div>${escapeHtml(j.content)}</div></div>`;
+    container.appendChild(stu);
+    if(j.teacher_reply){
+      const tea=document.createElement('div');
+      tea.className='text-right';
+      tea.innerHTML=`<div class="inline-block bg-green-100 p-2 rounded"><div class="text-xs text-gray-500">${j.replied_at}</div><div>${escapeHtml(j.teacher_reply)}</div></div>`;
+      container.appendChild(tea);
+    }
+  });
+}
+
+function loadJournals(id, container){
+  fetch('fetch_journals.php?student_id='+id)
+    .then(r=>r.json())
+    .then(d=>{renderJournals(container, d.journals || []);});
+}
+
+document.querySelectorAll('.toggle-journal').forEach(btn=>{
+  btn.addEventListener('click',()=>{
+    const id=btn.dataset.id;
+    const row=document.getElementById('journal-row-'+id);
+    row.classList.toggle('hidden');
+    if(!row.dataset.loaded){
+      loadJournals(id, row.querySelector('.journal-messages'));
+      row.dataset.loaded='1';
+    }
+  });
+});
+
+document.querySelectorAll('.reply-form').forEach(frm=>{
+  frm.addEventListener('submit',e=>{
+    e.preventDefault();
+    const id=frm.dataset.id;
+    const textarea=frm.querySelector('textarea');
+    const container=frm.parentElement.querySelector('.journal-messages');
+    fetch('teacher_reply.php',{method:'POST',headers:{'Content-Type':'application/x-www-form-urlencoded'},body:new URLSearchParams({student_id:id,reply:textarea.value,csrf_token:csrfToken})})
+      .then(r=>r.json())
+      .then(d=>{
+        if(d.success){
+          textarea.value='';
+          loadJournals(id, container);
+          const badge=document.querySelector('.badge-'+id);
+          if(badge) badge.remove();
+        }
+      });
+  });
+});
+</script>
 <?php include 'footer.php'; ?>

--- a/teacher_reply.php
+++ b/teacher_reply.php
@@ -1,0 +1,43 @@
+<?php
+define('REQUIRE_LOGIN', true);
+require 'config.php';
+
+if (($_SESSION['role'] ?? '') !== 'teacher') {
+    http_response_code(403);
+    exit;
+}
+
+header('Content-Type: application/json; charset=utf-8');
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    echo json_encode(['error' => 'invalid_method']);
+    exit;
+}
+
+csrf_check($_POST['csrf_token'] ?? null);
+$student_id = (int)($_POST['student_id'] ?? 0);
+$reply = trim($_POST['reply'] ?? '');
+if ($student_id <= 0 || $reply === '') {
+    echo json_encode(['error' => 'invalid_input']);
+    exit;
+}
+
+try {
+    $db->beginTransaction();
+    $stmt = $db->prepare('SELECT id FROM journals WHERE student_id = ? AND teacher_reply IS NULL ORDER BY meditation_at DESC LIMIT 1');
+    $stmt->execute([$student_id]);
+    $journal_id = $stmt->fetchColumn();
+    if ($journal_id) {
+        $up = $db->prepare('UPDATE journals SET teacher_reply = ?, replied_at = NOW(), seen_at = NOW() WHERE id = ?');
+        $up->execute([$reply, $journal_id]);
+        $seen = $db->prepare('UPDATE journals SET seen_at = NOW() WHERE student_id = ? AND seen_at IS NULL');
+        $seen->execute([$student_id]);
+        $db->commit();
+        echo json_encode(['success' => true]);
+    } else {
+        $db->rollBack();
+        echo json_encode(['error' => 'no_journal']);
+    }
+} catch (Throwable $e) {
+    if ($db->inTransaction()) $db->rollBack();
+    echo json_encode(['error' => 'db_error']);
+}


### PR DESCRIPTION
## Summary
- replace email column with daily journal column and per-student journal accordion
- add JSON endpoint to fetch student journals
- allow teachers to reply to journals and mark entries as seen

## Testing
- `php -l teacher_dashboard.php`
- `php -l fetch_journals.php`
- `php -l teacher_reply.php`
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6895c19d9ffc83268bd8a9a7d34edfdb