### PR TITLE
Fix teacher dashboard queries for user_id journal data

### DIFF
--- a/fetch_journals.php
+++ b/fetch_journals.php
@@ -8,15 +8,15 @@ if (($_SESSION['role'] ?? '') !== 'teacher') {
 }
 
 header('Content-Type: application/json; charset=utf-8');
-$student_id = (int)($_GET['student_id'] ?? 0);
-if ($student_id <= 0) {
+$user_id = (int)($_GET['user_id'] ?? 0);
+if ($user_id <= 0) {
     echo json_encode(['error' => 'invalid_id']);
     exit;
 }
 
 try {
-    $stmt = $db->prepare('SELECT id, meditation_at, content, teacher_reply, replied_at FROM journals WHERE student_id = ? ORDER BY meditation_at ASC');
-    $stmt->execute([$student_id]);
+    $stmt = $db->prepare('SELECT id, meditation_at, content, teacher_reply, replied_at FROM journals WHERE user_id = ? ORDER BY meditation_at ASC');
+    $stmt->execute([$user_id]);
     $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
     echo json_encode(['journals' => $rows], JSON_UNESCAPED_UNICODE);
 } catch (Throwable $e) {

--- a/teacher_reply.php
+++ b/teacher_reply.php
@@ -14,23 +14,23 @@ if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
 }
 
 csrf_check($_POST['csrf_token'] ?? null);
-$student_id = (int)($_POST['student_id'] ?? 0);
+$user_id = (int)($_POST['user_id'] ?? 0);
 $reply = trim($_POST['reply'] ?? '');
-if ($student_id <= 0 || $reply === '') {
+if ($user_id <= 0 || $reply === '') {
     echo json_encode(['error' => 'invalid_input']);
     exit;
 }
 
 try {
     $db->beginTransaction();
-    $stmt = $db->prepare('SELECT id FROM journals WHERE student_id = ? AND teacher_reply IS NULL ORDER BY meditation_at DESC LIMIT 1');
-    $stmt->execute([$student_id]);
+    $stmt = $db->prepare('SELECT id FROM journals WHERE user_id = ? AND teacher_reply IS NULL ORDER BY meditation_at DESC LIMIT 1');
+    $stmt->execute([$user_id]);
     $journal_id = $stmt->fetchColumn();
     if ($journal_id) {
         $up = $db->prepare('UPDATE journals SET teacher_reply = ?, replied_at = NOW(), seen_at = NOW() WHERE id = ?');
         $up->execute([$reply, $journal_id]);
-        $seen = $db->prepare('UPDATE journals SET seen_at = NOW() WHERE student_id = ? AND seen_at IS NULL');
-        $seen->execute([$student_id]);
+        $seen = $db->prepare('UPDATE journals SET seen_at = NOW() WHERE user_id = ? AND seen_at IS NULL');
+        $seen->execute([$user_id]);
         $db->commit();
         echo json_encode(['success' => true]);
     } else {


### PR DESCRIPTION
## Summary
- Show students even without sessions or journals by LEFT JOINing sessions and journals and filtering by `user_id`
- Count distinct sessions and flag whether a journal was submitted today
- Switch AJAX endpoints and replies to use `user_id` instead of `student_id`

## Testing
- `php -l teacher_dashboard.php`
- `php -l fetch_journals.php`
- `php -l teacher_reply.php`
- `composer install` *(failed: Required package "phpmailer/phpmailer" is not present in the lock file)*
- `composer update` *(failed: curl error 56 CONNECT tunnel failed, response 403)*
- `phpunit tests` *(command not found)*
- `apt-get update` *(failed: repository InRelease 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_6895d4b4a8408326bc678aea5041a123