### PR TITLE
Improve student meditation reporting workflow

### DIFF
--- a/dashboard.php
+++ b/dashboard.php
@@ -66,7 +66,7 @@ require 'header.php';
     <div class="text-center mb-6 text-lg font-semibold text-green-700 flex flex-col items-center">
       🌿 <span><?= sprintf(__('remaining_sessions'), $remain) ?></span>
     </div>
-    <div class="flex flex-col md:flex-row gap-4 mb-6">
+    <div class="flex flex-col md:flex-row gap-4 mb-4">
         <div class="flex-1 bg-white/90 rounded-xl shadow p-4 flex flex-col items-center border border-mint/30">
           <div class="mb-2 font-semibold text-base text-mint-text"><?= __('morning_class') ?> <span class="text-gray-400 text-sm">06:00-06:40</span></div>
           <form method="post" action="join.php" class="w-full">
@@ -92,6 +92,12 @@ require 'header.php';
           </form>
         </div>
     </div>
+    <div class="mb-6">
+      <a href="student_journal.php"
+         class="block w-full rounded-xl bg-gradient-to-tr from-[#b6f0de] to-[#9dcfc3] text-[#285F57] font-bold py-2 text-center shadow-lg hover:scale-[1.03] hover:shadow-xl transition focus:ring-2 focus:ring-mint-dark outline-none">
+         Báo Thiền
+      </a>
+    </div>
     <h5 class="text-center text-base font-semibold text-mint-text mt-2 mb-3"><?= __('recent_history') ?></h5>
     <div class="overflow-x-auto">
       <table class="w-full text-sm bg-white border border-gray-100 rounded-lg">
@@ -115,9 +121,8 @@ require 'header.php';
         </tbody>
       </table>
     </div>
-    <div class="text-center mt-4 space-x-4">
+    <div class="text-center mt-4">
       <a href="change_password.php" class="text-sm text-blue-600 underline"><?= __('change_password') ?></a>
-      <a href="student_journal.php" class="text-sm text-blue-600 underline">Nhật ký thiền</a>
     </div>
   </div>
 </main>

--- a/journal.php
+++ b/journal.php
@@ -26,28 +26,23 @@ if (!$student) {
 }
 
 // Fetch journals
-$stmt = $db->prepare("SELECT id, meditation_at, content, teacher_reply FROM journals WHERE user_id = ? ORDER BY meditation_at DESC");
+$stmt = $db->prepare("SELECT id, meditation_at, content, teacher_reply, replied_at FROM journals WHERE user_id = ? ORDER BY meditation_at DESC");
 $stmt->execute([$student_id]);
 $journals = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
-$pageTitle = 'Nhật ký: ' . $student['full_name'];
+$pageTitle = 'Báo Thiền: ' . $student['full_name'];
 require 'header.php';
 ?>
 <main class="max-w-3xl mx-auto p-4">
-  <h2 class="text-2xl font-bold mb-4">Nhật ký của <?= htmlspecialchars($student['full_name']) ?></h2>
+  <h2 class="text-2xl font-bold mb-4">Báo Thiền của <?= htmlspecialchars($student['full_name']) ?></h2>
   <div class="space-y-6">
     <?php foreach ($journals as $j): ?>
-      <div class="bg-white p-4 rounded shadow">
-        <div class="text-sm text-gray-500 mb-2">
-          <?= date('d/m/Y H:i', strtotime($j['meditation_at'])) ?>
-        </div>
-        <div class="whitespace-pre-line mb-2"><?= htmlspecialchars($j['content']) ?></div>
+      <div class="bg-white p-4 rounded shadow space-y-2">
+        <div><?= date('d/m/Y', strtotime($j['meditation_at'])) ?>: <?= htmlspecialchars($j['content']) ?></div>
         <?php if ($j['teacher_reply']): ?>
-          <div class="mt-2 p-2 bg-gray-50 border-l-4 border-green-400">
-            <strong>Phản hồi:</strong> <?= htmlspecialchars($j['teacher_reply']) ?>
-          </div>
+          <div><?= date('d/m/Y', strtotime($j['replied_at'])) ?>: Giáo viên phản hồi: <?= htmlspecialchars($j['teacher_reply']) ?></div>
         <?php else: ?>
-          <form method="post" action="reply_journal.php" class="mt-2 space-y-2">
+          <form method="post" action="reply_journal.php" class="space-y-2">
             <input type="hidden" name="csrf_token" value="<?= $_SESSION['csrf_token']; ?>">
             <input type="hidden" name="journal_id" value="<?= $j['id'] ?>">
             <input type="hidden" name="student_id" value="<?= $student_id ?>">

--- a/teacher_dashboard.php
+++ b/teacher_dashboard.php
@@ -89,17 +89,21 @@ function escapeHtml(str){
   return str.replace(/[&<>"']/g,m=>map[m]);
 }
 
+function formatDate(str){
+  const d=new Date(str);
+  return d.toLocaleDateString('vi-VN');
+}
 function renderJournals(container, journals){
   container.innerHTML='';
   journals.forEach(j=>{
     const stu=document.createElement('div');
     stu.className='text-left';
-    stu.innerHTML=`<div class="inline-block bg-gray-100 p-2 rounded"><div class="text-xs text-gray-500">${j.meditation_at}</div><div>${escapeHtml(j.content)}</div></div>`;
+    stu.innerHTML=`<div class="inline-block bg-gray-100 p-2 rounded">${formatDate(j.meditation_at)}: ${escapeHtml(j.content)}</div>`;
     container.appendChild(stu);
     if(j.teacher_reply){
       const tea=document.createElement('div');
       tea.className='text-right';
-      tea.innerHTML=`<div class="inline-block bg-green-100 p-2 rounded"><div class="text-xs text-gray-500">${j.replied_at}</div><div>${escapeHtml(j.teacher_reply)}</div></div>`;
+      tea.innerHTML=`<div class="inline-block bg-green-100 p-2 rounded">${formatDate(j.replied_at)}: ${escapeHtml(j.teacher_reply)}</div>`;
       container.appendChild(tea);
     }
   });


### PR DESCRIPTION
## Summary
- Rename "Nhật ký thiền" to "Báo Thiền" button and place below join-class buttons on dashboard
- Structure student meditation report form with session counts, duration and status
- Show student and teacher meditation logs in unified format across views

## Testing
- `vendor/bin/phpunit --testdox` *(fails: No such file or directory)*
- `phpunit --testdox` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689966d7442c8326a9dba1a2564f6968