### PR TITLE
Order journals by submission time

### DIFF
--- a/fetch_journals.php
+++ b/fetch_journals.php
@@ -15,16 +15,16 @@ if ($user_id <= 0) {
 }
 
 try {
-    $stmt = $db->prepare('SELECT meditation_at, content, teacher_reply, replied_at FROM journals WHERE user_id = ?');
+    $stmt = $db->prepare('SELECT meditation_at, created_at, content, teacher_reply, replied_at FROM journals WHERE user_id = ?');
     $stmt->execute([$user_id]);
     $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
     $messages = [];
     foreach ($rows as $r) {
         $messages[] = [
-            'created_at' => $r['meditation_at'],
+            'created_at' => $r['created_at'],
             'role' => 'student',
-            'content' => $r['content'],
+            'content' => date('d/m/Y H:i', strtotime($r['meditation_at'])) . ': ' . $r['content'],
         ];
         if (!empty($r['teacher_reply'])) {
             $messages[] = [

--- a/journal.php
+++ b/journal.php
@@ -26,7 +26,7 @@ if (!$student) {
 }
 
 // Fetch journals
-$stmt = $db->prepare("SELECT id, meditation_at, content, teacher_reply, replied_at FROM journals WHERE user_id = ? ORDER BY meditation_at DESC");
+$stmt = $db->prepare("SELECT id, meditation_at, created_at, content, teacher_reply, replied_at FROM journals WHERE user_id = ? ORDER BY created_at DESC");
 $stmt->execute([$student_id]);
 $journals = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
@@ -36,22 +36,22 @@ require 'header.php';
 <main class="max-w-3xl mx-auto p-4">
   <h2 class="text-2xl font-bold mb-4">Báo Thiền của <?= htmlspecialchars($student['full_name']) ?></h2>
   <div class="space-y-6">
-    <?php foreach ($journals as $j): ?>
-      <div class="bg-white p-4 rounded shadow space-y-2">
-        <div><?= date('d/m/Y', strtotime($j['meditation_at'])) ?>: <?= htmlspecialchars($j['content']) ?></div>
-        <?php if ($j['teacher_reply']): ?>
-          <div><?= date('d/m/Y', strtotime($j['replied_at'])) ?>: Giáo viên phản hồi: <?= htmlspecialchars($j['teacher_reply']) ?></div>
-        <?php else: ?>
-          <form method="post" action="reply_journal.php" class="space-y-2">
-            <input type="hidden" name="csrf_token" value="<?= $_SESSION['csrf_token']; ?>">
-            <input type="hidden" name="journal_id" value="<?= $j['id'] ?>">
-            <input type="hidden" name="student_id" value="<?= $student_id ?>">
-            <textarea name="reply" class="w-full border px-3 py-2 rounded" required></textarea>
-            <button type="submit" class="bg-[#9dcfc3] text-white px-4 py-1 rounded">Gửi phản hồi</button>
-          </form>
-        <?php endif; ?>
-      </div>
-    <?php endforeach; ?>
+      <?php foreach ($journals as $j): ?>
+        <div class="bg-white p-4 rounded shadow space-y-2">
+          <div><?= date('d/m/Y H:i', strtotime($j['meditation_at'])) ?>: <?= htmlspecialchars($j['content']) ?></div>
+          <?php if ($j['teacher_reply']): ?>
+            <div><?= date('d/m/Y H:i', strtotime($j['replied_at'])) ?>: Giáo viên phản hồi: <?= htmlspecialchars($j['teacher_reply']) ?></div>
+          <?php else: ?>
+            <form method="post" action="reply_journal.php" class="space-y-2">
+              <input type="hidden" name="csrf_token" value="<?= $_SESSION['csrf_token']; ?>">
+              <input type="hidden" name="journal_id" value="<?= $j['id'] ?>">
+              <input type="hidden" name="student_id" value="<?= $student_id ?>">
+              <textarea name="reply" class="w-full border px-3 py-2 rounded" required></textarea>
+              <button type="submit" class="bg-[#9dcfc3] text-white px-4 py-1 rounded">Gửi phản hồi</button>
+            </form>
+          <?php endif; ?>
+        </div>
+      <?php endforeach; ?>
   </div>
 </main>
 <?php include 'footer.php'; ?>

--- a/student_journal.php
+++ b/student_journal.php
@@ -23,16 +23,16 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     exit;
 }
 
-$stmt = $db->prepare("SELECT meditation_at, content, teacher_reply, replied_at FROM journals WHERE user_id = ? ORDER BY meditation_at ASC");
+$stmt = $db->prepare("SELECT meditation_at, created_at, content, teacher_reply, replied_at FROM journals WHERE user_id = ? ORDER BY created_at ASC");
 $stmt->execute([$uid]);
 $journals = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
 $messages = [];
 foreach ($journals as $j) {
     $messages[] = [
-        'time' => $j['meditation_at'],
+        'time' => $j['created_at'],
         'role' => 'student',
-        'content' => $j['content'],
+        'content' => date('d/m/Y H:i', strtotime($j['meditation_at'])) . ': ' . $j['content'],
     ];
     if (!empty($j['teacher_reply'])) {
         $messages[] = [

--- a/teacher_dashboard.php
+++ b/teacher_dashboard.php
@@ -19,9 +19,10 @@ try {
             COUNT(DISTINCT s.id) AS session_count,
             COUNT(j.id) AS journal_count,
             (
-                SELECT content FROM journals j2
+                SELECT CONCAT(DATE_FORMAT(j2.meditation_at, '%d/%m/%Y %H:%i'), ': ', j2.content)
+                FROM journals j2
                 WHERE j2.user_id = u.id
-                ORDER BY j2.meditation_at DESC
+                ORDER BY j2.created_at DESC
                 LIMIT 1
             ) AS last_journal
         FROM users u

--- a/teacher_reply.php
+++ b/teacher_reply.php
@@ -23,7 +23,7 @@ if ($user_id <= 0 || $reply === '') {
 
 try {
     $db->beginTransaction();
-    $stmt = $db->prepare('SELECT id FROM journals WHERE user_id = ? AND teacher_reply IS NULL ORDER BY meditation_at DESC LIMIT 1');
+    $stmt = $db->prepare('SELECT id FROM journals WHERE user_id = ? AND teacher_reply IS NULL ORDER BY created_at DESC LIMIT 1');
     $stmt->execute([$user_id]);
     $journal_id = $stmt->fetchColumn();
     if ($journal_id) {


### PR DESCRIPTION
## Summary
- Use `created_at` timestamps to order meditation journals, ensuring chat logs display by submission time.
- Automatically prepend the student-entered meditation time to journal messages for both student and teacher views.
- Update teacher dashboard and reply handling to use `created_at`, keeping latest entries at the top.

## Testing
- `php -l student_journal.php fetch_journals.php journal.php teacher_dashboard.php teacher_reply.php`
- `vendor/bin/phpunit -c phpunit.xml` *(fails: No such file or directory)*


------
https://chatgpt.com/codex/tasks/task_b_6899b10dc718832696227b8c330c7196