### PR TITLE
Integrate Google Tag Manager snippets across pages

### DIFF
--- a/header.php
+++ b/header.php
@@ -4,17 +4,15 @@ require_once __DIR__ . '/i18n.php';
 <!DOCTYPE html>
 <html lang="<?= $_SESSION['lang'] ?? 'vi' ?>">
 <head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-PNFMJD34');</script>
+  <!-- End Google Tag Manager -->
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <!-- Google tag (gtag.js) -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=AW-16673835420"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-
-    gtag('config', 'AW-16673835420');
-  </script>
   <title><?= isset($pageTitle) ? htmlspecialchars($pageTitle) : 'NamaHealing' ?></title>
   <?php if (!empty($metaDescription)): ?>
     <meta name="description" content="<?= htmlspecialchars($metaDescription) ?>">
@@ -48,13 +46,6 @@ require_once __DIR__ . '/i18n.php';
       letter-spacing: .01em;
     }
   </style>
-  <!-- Google Tag Manager -->
-  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-  })(window,document,'script','dataLayer','GTM-PNFMJD34');</script>
-  <!-- End Google Tag Manager -->
 </head>
 <body class="bg-[#f9fafb] text-[#374151] pt-20 sm:pt-16">
   <!-- Google Tag Manager (noscript) -->

--- a/home.php
+++ b/home.php
@@ -5,17 +5,15 @@ require 'config.php';
 <!DOCTYPE html>
 <html lang="vi">
 <head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-PNFMJD34');</script>
+  <!-- End Google Tag Manager -->
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <!-- Google tag (gtag.js) -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=AW-16673835420"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-
-    gtag('config', 'AW-16673835420');
-  </script>
   <title>NAMA HEALING – Home</title>
 
   <!-- TailwindCSS -->
@@ -131,13 +129,6 @@ require 'config.php';
   }
 
   </style>
-  <!-- Google Tag Manager -->
-  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-  })(window,document,'script','dataLayer','GTM-PNFMJD34');</script>
-  <!-- End Google Tag Manager -->
 </head>
 
 <body class="overflow-x-hidden">

--- a/join.php
+++ b/join.php
@@ -1,6 +1,19 @@
 <?php
 define('REQUIRE_LOGIN', true);
 require 'config.php';
+
+$gtm_head = <<<'HTML'
+<!-- Google Tag Manager -->
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-PNFMJD34');</script>
+<!-- End Google Tag Manager -->
+HTML;
+
+$gtm_body = <<<'HTML'
+<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-PNFMJD34" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->
+HTML;
+
 if (!isset($_SESSION['uid']) || $_SESSION['role'] !== 'student') {
     header('Location: login.php'); exit;
 }
@@ -27,7 +40,7 @@ if ($session === 'morning') {
 
 if (!$allowed) {
     $title = $session === 'morning' ? __('join_morning') : __('join_evening');
-    echo "<!DOCTYPE html><html><head><meta charset='utf-8'><title>{$title}</title></head><body><p>" . __('not_class_time') . "</p></body></html>";
+    echo "<!DOCTYPE html><html><head>{$gtm_head}<meta charset='utf-8'><title>{$title}</title></head><body>{$gtm_body}<p>" . __('not_class_time') . "</p></body></html>";
     exit;
 }
 
@@ -64,10 +77,10 @@ if ($remain > 0) {
         $app_url = $url;
     }
     $fallback_url = $url;
-    echo "<!DOCTYPE html><html><head><meta charset='utf-8'><title>Redirecting...</title>";
+    echo "<!DOCTYPE html><html><head>{$gtm_head}<meta charset='utf-8'><title>Redirecting...</title>";
     echo "<script>window.location.href=" . json_encode($app_url) . ";";
     echo "setTimeout(function(){window.location.href=" . json_encode($fallback_url) . ";},2000);";
-    echo "</script></head><body><p>Redirecting to Zoom...</p></body></html>";
+    echo "</script></head><body>{$gtm_body}<p>Redirecting to Zoom...</p></body></html>";
     exit;
 }
 


### PR DESCRIPTION
## Summary
- Add Google Tag Manager script and noscript blocks to shared header template
- Replace legacy analytics code on home page with GTM snippet
- Embed GTM snippet into join flow pages

## Testing
- `php -l header.php`
- `php -l home.php`
- `php -l join.php`
- `composer install` *(failed: lock file missing phpmailer)*
- `phpunit tests` *(failed: command not found)*
- `apt-get update` *(failed: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_b_6899cfef5c3883268cecd3aae34546af