### PR TITLE
Allow students to log meditation by date only

### DIFF
--- a/fetch_journals.php
+++ b/fetch_journals.php
@@ -24,7 +24,7 @@ try {
         $messages[] = [
             'created_at' => $r['created_at'],
             'role' => 'student',
-            'content' => date('d/m/Y H:i', strtotime($r['meditation_at'])) . ': ' . $r['content'],
+            'content' => date('d/m/Y', strtotime($r['meditation_at'])) . ': ' . $r['content'],
         ];
         if (!empty($r['teacher_reply'])) {
             $messages[] = [

--- a/journal.php
+++ b/journal.php
@@ -38,7 +38,7 @@ require 'header.php';
   <div class="space-y-6">
       <?php foreach ($journals as $j): ?>
         <div class="bg-white p-4 rounded shadow space-y-2">
-          <div><?= date('d/m/Y H:i', strtotime($j['meditation_at'])) ?>: <?= htmlspecialchars($j['content']) ?></div>
+          <div><?= date('d/m/Y', strtotime($j['meditation_at'])) ?>: <?= htmlspecialchars($j['content']) ?></div>
           <?php if ($j['teacher_reply']): ?>
             <div><?= date('d/m/Y H:i', strtotime($j['replied_at'])) ?>: Giáo viên phản hồi: <?= htmlspecialchars($j['teacher_reply']) ?></div>
           <?php else: ?>

--- a/student_journal.php
+++ b/student_journal.php
@@ -32,7 +32,7 @@ foreach ($journals as $j) {
     $messages[] = [
         'time' => $j['created_at'],
         'role' => 'student',
-        'content' => date('d/m/Y H:i', strtotime($j['meditation_at'])) . ': ' . $j['content'],
+        'content' => date('d/m/Y', strtotime($j['meditation_at'])) . ': ' . $j['content'],
     ];
     if (!empty($j['teacher_reply'])) {
         $messages[] = [
@@ -51,8 +51,8 @@ require 'header.php';
   <form method="post" class="bg-white p-4 rounded shadow space-y-4">
     <input type="hidden" name="csrf_token" value="<?= $_SESSION['csrf_token']; ?>">
     <div>
-      <label class="block mb-1">Thời gian thiền</label>
-      <input type="datetime-local" name="meditation_at" class="w-full border px-3 py-2 rounded" required>
+      <label class="block mb-1">Ngày thiền</label>
+      <input type="date" name="meditation_at" class="w-full border px-3 py-2 rounded" required>
     </div>
     <div>
       <label class="block mb-1">Số thời thiền</label>

--- a/teacher_dashboard.php
+++ b/teacher_dashboard.php
@@ -19,7 +19,7 @@ try {
             COUNT(DISTINCT s.id) AS session_count,
             COUNT(j.id) AS journal_count,
             (
-                SELECT DATE_FORMAT(j2.meditation_at, '%d/%m/%Y %H:%i')
+                SELECT DATE_FORMAT(j2.meditation_at, '%d/%m/%Y')
                 FROM journals j2
                 WHERE j2.user_id = u.id
                 ORDER BY j2.created_at DESC


### PR DESCRIPTION
## Summary
- Use a date picker for student meditation reports instead of datetime
- Display meditation entries with only the selected date throughout teacher and student views

## Testing
- `vendor/bin/phpunit || phpunit || echo 'no tests'`


------
https://chatgpt.com/codex/tasks/task_b_6899d9c2de4083269749087a612e686b