### PR TITLE
Add translations for chatbot interface

### DIFF
--- a/chatbot.php
+++ b/chatbot.php
@@ -5,11 +5,11 @@ include 'header.php';
 ?>
 <main class="flex flex-col items-center min-h-screen px-4 pt-4 pb-20">
   <h1 class="text-2xl font-semibold mb-4 w-full max-w-lg text-center">
-    <?= __('NamaHealing Bot') ?>
+    <?= __('chatbot_title') ?>
   </h1>
   <div id="chat-log" class="w-full max-w-lg flex-1 overflow-y-auto space-y-3 pb-4">
     <div id="greeting" class="text-center text-gray-500 bg-white border border-gray-200 rounded-lg p-4">
-      NamaHealing Bot - Tư vấn lớp thiền chữa lành tâm lý
+      <?= __('chatbot_greeting') ?>
     </div>
   </div>
   <form id="chat-form" class="fixed bottom-0 left-1/2 transform -translate-x-1/2 w-full max-w-lg flex gap-2 px-4 py-3 bg-white border-t border-gray-200 shadow-md z-10" style="padding-bottom: calc(0.75rem + env(safe-area-inset-bottom));">

--- a/lang/en.php
+++ b/lang/en.php
@@ -113,6 +113,8 @@ return [
     'home_docs_chant' => 'Chanting Books',
     'home_docs_reference' => 'Reference Books',
     'chatbot' => 'Chatbot',
+    'chatbot_title' => 'NamaHealing Bot',
+    'chatbot_greeting' => 'NamaHealing Bot - Meditation class support',
     'chatbot_placeholder' => 'Type your question…',
     'chatbot_send' => 'Send',
     'placeholder_name' => 'Full name',

--- a/lang/uk.php
+++ b/lang/uk.php
@@ -113,6 +113,8 @@ return [
     'home_docs_chant' => 'Книги мантр',
     'home_docs_reference' => 'Довідкова література',
     'chatbot' => 'Чат-бот',
+    'chatbot_title' => 'NamaHealing Bot',
+    'chatbot_greeting' => 'NamaHealing Bot - Підтримка класу медитації для зцілення',
     'chatbot_placeholder' => 'Введіть ваше питання…',
     'chatbot_send' => 'Надіслати',
     'placeholder_name' => 'ПІБ',

--- a/lang/vi.php
+++ b/lang/vi.php
@@ -113,6 +113,8 @@ return [
     'home_docs_chant' => 'Sách Kinh Tụng',
     'home_docs_reference' => 'Sách Tham Khảo',
     'chatbot' => 'Chatbot',
+    'chatbot_title' => 'NamaHealing Bot',
+    'chatbot_greeting' => 'NamaHealing Bot - Tư vấn lớp thiền chữa lành tâm lý',
     'chatbot_placeholder' => 'Nhập câu hỏi của bạn…',
     'chatbot_send' => 'Gửi',
     'placeholder_name' => 'Họ và Tên',


### PR DESCRIPTION
## Summary
- Add dedicated translation keys for chatbot title and greeting
- Localize chatbot title and greeting in Vietnamese, English, and Ukrainian

## Testing
- `php -l chatbot.php lang/vi.php lang/en.php lang/uk.php`
- `composer require --dev phpunit/phpunit -W` *(fails: CONNECT tunnel failed, response 403)*
- `vendor/bin/phpunit tests` *(fails: vendor/bin/phpunit: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_689bef47757c832696e8f13dabb40fbc