### PR TITLE
Implement password reset token generation

### DIFF
--- a/controllers/ForgotPasswordController.php
+++ b/controllers/ForgotPasswordController.php
@@ -1,0 +1,47 @@
+<?php
+namespace NamaHealing\Controllers;
+
+use PDO;
+use NamaHealing\Models\UserModel;
+use NamaHealing\Helpers\Mailer;
+
+class ForgotPasswordController {
+    private PDO $db;
+
+    public function __construct(PDO $db) {
+        $this->db = $db;
+        // Ensure password_resets table exists
+        $this->db->exec("CREATE TABLE IF NOT EXISTS password_resets (
+            id INT AUTO_INCREMENT PRIMARY KEY,
+            user_id INT NOT NULL,
+            token VARCHAR(64) NOT NULL,
+            expires_at DATETIME NOT NULL,
+            INDEX token_idx (token)
+        )");
+    }
+
+    public function handle(): void {
+        $message = '';
+        if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+            csrf_check($_POST['csrf_token'] ?? null);
+            $email = trim($_POST['email'] ?? '');
+            if ($email !== '') {
+                $model = new UserModel($this->db);
+                $user = $model->findByIdentifier($email);
+                if ($user) {
+                    $token = bin2hex(random_bytes(32));
+                    $expiresAt = date('Y-m-d H:i:s', time() + 3600); // 1 hour
+                    $model->createResetToken((int)$user['id'], $token, $expiresAt);
+                    $scheme = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') ? 'https://' : 'http://';
+                    $host = $_SERVER['HTTP_HOST'] ?? 'localhost';
+                    $link = $scheme . $host . '/reset_password.php?token=' . urlencode($token);
+                    $body = '<p>Click the link below to reset your password:</p>'
+                          . '<p><a href="' . $link . '">' . $link . '</a></p>';
+                    Mailer::send($email, 'Password Reset', $body);
+                }
+            }
+            $message = 'If the email exists, a reset link has been sent.';
+        }
+        include __DIR__ . '/../views/forgot_password.php';
+    }
+}

--- a/forgot_password.php
+++ b/forgot_password.php
@@ -1,0 +1,7 @@
+<?php
+require 'config.php';
+
+use NamaHealing\Controllers\ForgotPasswordController;
+
+$controller = new ForgotPasswordController($db);
+$controller->handle();

--- a/models/UserModel.php
+++ b/models/UserModel.php
@@ -29,5 +29,25 @@ class UserModel {
         $stmt = $this->db->prepare($sql);
         $stmt->execute([$name, $email, $phone, $hash]);
     }
+
+    /**
+     * Store a password reset token for a user.
+     */
+    public function createResetToken(int $userId, string $token, string $expiresAt): void {
+        $sql = "INSERT INTO password_resets (user_id, token, expires_at) VALUES (?, ?, ?)";
+        $stmt = $this->db->prepare($sql);
+        $stmt->execute([$userId, $token, $expiresAt]);
+    }
+
+    /**
+     * Find a reset token record if it hasn't expired.
+     */
+    public function findResetToken(string $token): ?array {
+        $sql = "SELECT * FROM password_resets WHERE token = ? AND expires_at > NOW() LIMIT 1";
+        $stmt = $this->db->prepare($sql);
+        $stmt->execute([$token]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $row ?: null;
+    }
 }
 

--- a/views/forgot_password.php
+++ b/views/forgot_password.php
@@ -1,0 +1,21 @@
+<?php include 'header.php'; ?>
+<main class="min-h-[75vh] flex items-center justify-center bg-gradient-to-br from-[#eafcf8] to-[#f8fafb] py-12">
+  <div class="w-full max-w-sm rounded-2xl bg-white/90 shadow-lg border border-[#9dcfc3]/40 p-8 backdrop-blur-[2px]">
+    <h2 class="text-center text-2xl font-bold mb-6 tracking-wide font-heading">Forgot Password</h2>
+    <?php if (!empty($message)): ?>
+      <div class="bg-green-50 border border-green-300 text-green-700 rounded-md px-3 py-2 text-sm mb-4 text-center">
+        <?= htmlspecialchars($message) ?>
+      </div>
+    <?php endif; ?>
+    <form method="post" class="space-y-5">
+      <input type="hidden" name="csrf_token" value="<?= $_SESSION['csrf_token']; ?>">
+      <div>
+        <label class="block text-sm font-medium text-[#285F57] mb-1">Email</label>
+        <input name="email" type="email" required autofocus
+          class="w-full px-4 py-2 border-2 border-[#9dcfc3] rounded-lg bg-gray-50 text-[#374151] focus:outline-none focus:border-[#76a89e] focus:bg-white transition" />
+      </div>
+      <button class="w-full mt-2 rounded-lg bg-[#9dcfc3] text-[#285F57] font-semibold py-2 shadow hover:bg-[#76a89e] hover:text-white transition">Send Reset Link</button>
+    </form>
+  </div>
+</main>
+<?php include 'footer.php'; ?>


### PR DESCRIPTION
## Summary
- add password reset token storage and lookup in `UserModel`
- create `ForgotPasswordController` to generate tokens, ensure table exists, and send emails
- add forgot password view and entry point

## Testing
- `php -l models/UserModel.php controllers/ForgotPasswordController.php views/forgot_password.php forgot_password.php`
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_689ebbab6f2c8326a262261b5c94508f