### PR TITLE
Fix and secure password reset workflow

### DIFF
--- a/controllers/ForgotPasswordController.php
+++ b/controllers/ForgotPasswordController.php
@@ -1,54 +1,68 @@
 <?php
-// controllers/ForgotPasswordController.php
 declare(strict_types=1);
 
+namespace NamaHealing\Controllers;
+
+use PDO;
+use NamaHealing\Helpers\Mailer;
+
 require_once __DIR__ . '/../helpers/Security.php';
-// ... require các model/mail cần thiết
 
-if (session_status() !== PHP_SESSION_ACTIVE) {
-    session_start();
-}
+class ForgotPasswordController
+{
+    private PDO $db;
 
-// GET: render form + ROTATE token mới mỗi lần
-if ($_SERVER['REQUEST_METHOD'] === 'GET') {
-    // chống cache để tránh form cũ -> token cũ
-    header('Cache-Control: no-store, no-cache, must-revalidate, max-age=0');
-    header('Pragma: no-cache');
-    $csrf = csrf_generate_token('forgot_password');
-    // truyền $csrf sang view (nếu view không tự gọi helper)
-    include __DIR__ . '/../views/forgot_password.php';
-    exit;
-}
-
-// POST: kiểm tra rate‑limit + CSRF
-if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    // 1) rate‑limit nhẹ, tránh spam
-    if (!ratelimit_pass('forgot_password', 5, 300)) {
-        http_response_code(429);
-        exit('Too many requests. Please try again later.');
+    public function __construct(PDO $db)
+    {
+        $this->db = $db;
     }
 
-    $posted = $_POST['csrf_token'] ?? null;
-    if (!csrf_verify_and_unset($posted, 'forgot_password', 900)) { // TTL 15 phút
-        http_response_code(400);
-        exit('Invalid CSRF token');
+    public function handle(): void
+    {
+        $message = '';
+
+        if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+            if (!ratelimit_pass('forgot_password', 5, 300)) {
+                http_response_code(429);
+                $message = 'Quá nhiều yêu cầu, vui lòng thử lại sau.';
+                include __DIR__ . '/../views/forgot_password.php';
+                return;
+            }
+
+            $posted = $_POST['csrf_token'] ?? null;
+            if (!csrf_verify_and_unset($posted, 'forgot_password', 900)) {
+                http_response_code(400);
+                $message = 'CSRF token không hợp lệ.';
+                include __DIR__ . '/../views/forgot_password.php';
+                return;
+            }
+
+            $email = trim((string)($_POST['email'] ?? ''));
+            if ($email !== '' && filter_var($email, FILTER_VALIDATE_EMAIL)) {
+                $stmt = $this->db->prepare('SELECT id FROM users WHERE email = ? LIMIT 1');
+                $stmt->execute([$email]);
+                $user = $stmt->fetch(PDO::FETCH_ASSOC);
+                if ($user) {
+                    $this->db->prepare('DELETE FROM password_resets WHERE user_id = ?')->execute([$user['id']]);
+                    $rawToken   = bin2hex(random_bytes(32));
+                    $tokenHash  = hash('sha256', $rawToken);
+                    $expires_at = date('Y-m-d H:i:s', time() + 3600);
+                    $ins = $this->db->prepare('INSERT INTO password_resets (user_id, token, expires_at) VALUES (?, ?, ?)');
+                    $ins->execute([$user['id'], $tokenHash, $expires_at]);
+
+                    $base = $_ENV['APP_URL'] ?? (($_SERVER['HTTPS'] ?? 'off') === 'on' ? 'https://' : 'http://') . ($_SERVER['HTTP_HOST'] ?? '') . dirname($_SERVER['PHP_SELF']);
+                    $link = rtrim($base, '/\\') . '/reset_password.php?token=' . $rawToken;
+                    $body = 'Nhấn vào liên kết sau để đặt lại mật khẩu: <a href="' . htmlspecialchars($link, ENT_QUOTES, 'UTF-8') . '">' . htmlspecialchars($link, ENT_QUOTES, 'UTF-8') . '</a>';
+                    Mailer::send($email, 'Đặt lại mật khẩu', $body);
+                }
+            }
+            $message = 'Nếu email tồn tại, chúng tôi đã gửi hướng dẫn đặt lại mật khẩu.';
+            include __DIR__ . '/../views/forgot_password.php';
+            return;
+        }
+
+        // GET
+        csrf_generate_token('forgot_password');
+        include __DIR__ . '/../views/forgot_password.php';
     }
-
-    // TODO: validate email server‑side
-    $email = trim((string)($_POST['email'] ?? ''));
-    if ($email === '' || !filter_var($email, FILTER_VALIDATE_EMAIL)) {
-        http_response_code(422);
-        exit('Email không hợp lệ.');
-    }
-
-    // ... phần còn lại: tìm user, xoá token cũ theo email, tạo token mới, gửi mail
-    // Gợi ý quan trọng:
-    // $pdo->prepare("DELETE FROM password_resets WHERE email = ?")->execute([$email]);
-    // $rawToken = bin2hex(random_bytes(32));
-    // $tokenHash = hash('sha256', $rawToken);
-    // INSERT tokenHash vào DB (cột token đổi thành 64 hex nếu dùng sha256)
-    // Gửi email chứa $rawToken trong URL (không bao giờ lưu raw vào DB)
-    // Trả về thông báo “Nếu email tồn tại... đã gửi hướng dẫn”.
-
-    exit('Nếu email tồn tại, chúng tôi đã gửi hướng dẫn đặt lại mật khẩu.');
 }

--- a/docs/password_resets.sql
+++ b/docs/password_resets.sql
@@ -1,0 +1,11 @@
+-- SQL schema for password_resets table
+CREATE TABLE `password_resets` (
+  `id` INT UNSIGNED NOT NULL AUTO_INCREMENT,
+  `user_id` INT UNSIGNED NOT NULL,
+  `token` CHAR(64) NOT NULL,
+  `expires_at` DATETIME NOT NULL,
+  `created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  KEY `token_idx` (`token`),
+  CONSTRAINT `password_resets_user_fk` FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/views/forgot_password.php
+++ b/views/forgot_password.php
@@ -6,6 +6,7 @@ require_once __DIR__ . '/../helpers/Security.php';
 
 // Lấy token đã sinh trong controller (nếu bạn thích để view tự sinh, có thể dùng csrf_generate_token('forgot_password'))
 $token = csrf_peek_token('forgot_password') ?? csrf_generate_token('forgot_password');
+$message = $message ?? '';
 ?>
 <!doctype html>
 <html lang="vi">
@@ -18,7 +19,10 @@ $token = csrf_peek_token('forgot_password') ?? csrf_generate_token('forgot_passw
   <meta http-equiv="Pragma" content="no-cache">
 </head>
 <body>
-  <form method="post" action="/forgot-password">
+  <?php if ($message): ?>
+    <p><?= htmlspecialchars($message, ENT_QUOTES, 'UTF-8') ?></p>
+  <?php endif; ?>
+  <form method="post" action="forgot_password.php">
     <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($token, ENT_QUOTES, 'UTF-8') ?>">
     <label>Email</label>
     <input type="email" name="email" required>


### PR DESCRIPTION
## Summary
- Implement robust `ForgotPasswordController` with CSRF, rate limiting, hashed tokens and mail notification
- Display status messages and correct form action in password reset request view
- Validate hashed reset tokens during password change
- Add SQL schema for `password_resets` table

## Testing
- `composer update` *(fails: CONNECT tunnel failed, response 403)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `php -l controllers/ForgotPasswordController.php`
- `php -l views/forgot_password.php`
- `php -l reset_password.php`

------
https://chatgpt.com/codex/tasks/task_b_689ffd6cb1248326812036900875d09e