### PR TITLE
refactor: unify namespaces and autoload

### DIFF
--- a/config.php
+++ b/config.php
@@ -2,6 +2,17 @@
 // Nạp Composer autoloader (nếu có)
 if (file_exists(__DIR__ . '/vendor/autoload.php')) {
     require_once __DIR__ . '/vendor/autoload.php';
+} else {
+    spl_autoload_register(function ($class) {
+        $prefix = 'NamaHealing\\';
+        if (str_starts_with($class, $prefix)) {
+            $class = substr($class, strlen($prefix));
+        }
+        $file = __DIR__ . '/' . str_replace('\\', '/', $class) . '.php';
+        if (file_exists($file)) {
+            require $file;
+        }
+    });
 }
 
 // Nạp biến môi trường từ file .env (nếu có)

--- a/controllers/ForgotPasswordController.php
+++ b/controllers/ForgotPasswordController.php
@@ -1,12 +1,12 @@
 <?php
-namespace controllers;
+namespace NamaHealing\Controllers;
 
-use helpers\Csrf;
-use helpers\Mailer;
-use helpers\RateLimiter;
-use helpers\Response;
-use models\UserModel;
-use models\PasswordResetModel;
+use NamaHealing\Helpers\Csrf;
+use NamaHealing\Helpers\Mailer;
+use NamaHealing\Helpers\RateLimiter;
+use NamaHealing\Helpers\Response;
+use NamaHealing\Models\UserModel;
+use NamaHealing\Models\PasswordResetModel;
 use PDO;
 
 class ForgotPasswordController {
@@ -27,7 +27,7 @@ class ForgotPasswordController {
 
     public function forgotForm(): void {
         Response::view('auth/forgot_password', [
-            'csrf' => \helpers\Csrf::token(),
+            'csrf' => Csrf::token(),
             'recaptcha_site_key' => getenv('RECAPTCHA_SITE_KEY'),
             'title' => 'Quên mật khẩu - NamaHealing',
             'description' => 'Nhập email để nhận mã OTP đặt lại mật khẩu',
@@ -75,7 +75,7 @@ class ForgotPasswordController {
 
     public function resetForm(): void {
         Response::view('auth/reset_password', [
-            'csrf' => \helpers\Csrf::token(),
+            'csrf' => Csrf::token(),
             'recaptcha_site_key' => getenv('RECAPTCHA_SITE_KEY'),
             'title' => 'Đặt lại mật khẩu - NamaHealing',
             'description' => 'Nhập OTP đã gửi qua email để đặt lại mật khẩu',

--- a/cron/send_email_queue.php
+++ b/cron/send_email_queue.php
@@ -1,10 +1,21 @@
 <?php
 declare(strict_types=1);
 
-require dirname(__DIR__).'/vendor/autoload.php';
+require dirname(__DIR__) . '/vendor/autoload.php';
+if (!class_exists('NamaHealing\\Helpers\\Mailer')) {
+    spl_autoload_register(function ($class) {
+        $prefix = 'NamaHealing\\';
+        if (str_starts_with($class, $prefix)) {
+            $class = substr($class, strlen($prefix));
+        }
+        $file = dirname(__DIR__) . '/' . str_replace('\\', '/', $class) . '.php';
+        if (file_exists($file)) {
+            require $file;
+        }
+    });
+}
 
-use helpers\Mailer;
-use PDO;
+use NamaHealing\Helpers\Mailer;
 
 // Nạp env
 if (class_exists(\Dotenv\Dotenv::class)) {

--- a/helpers/Csrf.php
+++ b/helpers/Csrf.php
@@ -1,5 +1,5 @@
 <?php
-namespace helpers;
+namespace NamaHealing\Helpers;
 
 class Csrf {
     public static function token(): string {

--- a/helpers/Mailer.php
+++ b/helpers/Mailer.php
@@ -1,5 +1,5 @@
 <?php
-namespace helpers;
+namespace NamaHealing\Helpers;
 
 use PHPMailer\PHPMailer\PHPMailer;
 use PDO;

--- a/helpers/RateLimiter.php
+++ b/helpers/RateLimiter.php
@@ -1,5 +1,5 @@
 <?php
-namespace helpers;
+namespace NamaHealing\Helpers;
 
 use PDO;
 

--- a/helpers/Response.php
+++ b/helpers/Response.php
@@ -1,5 +1,5 @@
 <?php
-namespace helpers;
+namespace NamaHealing\Helpers;
 
 class Response {
     public static function view(string $view, array $data = [], int $status = 200): void {

--- a/index.php
+++ b/index.php
@@ -14,15 +14,18 @@ define('BASE_PATH', dirname(__DIR__));
 $composer = BASE_PATH . '/vendor/autoload.php';
 if (file_exists($composer)) {
     require $composer;
+} else {
+    spl_autoload_register(function ($class) {
+        $prefix = 'NamaHealing\\';
+        if (str_starts_with($class, $prefix)) {
+            $class = substr($class, strlen($prefix));
+        }
+        $file = BASE_PATH . '/' . str_replace('\\', '/', $class) . '.php';
+        if (file_exists($file)) {
+            require $file;
+        }
+    });
 }
-spl_autoload_register(function ($class) {
-    $paths = [
-        BASE_PATH . '/controllers/' . $class . '.php',
-        BASE_PATH . '/models/' . $class . '.php',
-        BASE_PATH . '/helpers/' . $class . '.php',
-    ];
-    foreach ($paths as $p) { if (file_exists($p)) { require $p; return; } }
-});
 
 // Nạp env (nếu có vlucas/phpdotenv)
 if (class_exists(\Dotenv\Dotenv::class)) {
@@ -33,8 +36,8 @@ if (class_exists(\Dotenv\Dotenv::class)) {
 $uri = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH) ?? '/';
 $uri = rtrim($uri, '/') ?: '/';
 
-use controllers\ForgotPasswordController;
-use helpers\Response;
+use NamaHealing\Controllers\ForgotPasswordController;
+use NamaHealing\Helpers\Response;
 
 // Router đơn giản
 try {

--- a/models/PasswordResetModel.php
+++ b/models/PasswordResetModel.php
@@ -1,5 +1,5 @@
 <?php
-namespace models;
+namespace NamaHealing\Models;
 
 use PDO;
 

--- a/models/UserModel.php
+++ b/models/UserModel.php
@@ -1,5 +1,5 @@
 <?php
-namespace models;
+namespace NamaHealing\Models;
 
 use PDO;
 

--- a/views/auth/forgot_password.php
+++ b/views/auth/forgot_password.php
@@ -23,7 +23,7 @@
   <div class="card">
     <h1>Quên mật khẩu</h1>
     <form id="forgotForm" method="post" action="/forgot-password/submit" novalidate>
-      <?= \helpers\Csrf::input() ?>
+      <?= \NamaHealing\Helpers\Csrf::input() ?>
       <input type="text" name="website" style="display:none">
       <label>Email</label>
       <input type="email" name="email" required placeholder="you@example.com">

--- a/views/auth/reset_password.php
+++ b/views/auth/reset_password.php
@@ -22,7 +22,7 @@
   <div class="card">
     <h1>Đặt lại mật khẩu</h1>
     <form id="resetForm" method="post" action="/reset-password/submit" novalidate>
-      <?= \helpers\Csrf::input() ?>
+      <?= \NamaHealing\Helpers\Csrf::input() ?>
       <input type="text" name="website" style="display:none">
       <label>Email</label><input type="email" name="email" required>
       <label>OTP (6 số)</label><input type="text" name="otp" inputmode="numeric" pattern="\d{6}" required>


### PR DESCRIPTION
## Summary
- ensure NamaHealing classes autoload without Composer
- standardize namespaces across helpers, models, and controllers
- drop unused PDO import in email queue worker

## Testing
- `find . -name "*.php" -print0 | xargs -0 -n1 php -l`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a3db6156648326b3b627a0004a836c