### PR TITLE
Fix base path and forgot password handler for 500 error

### DIFF
--- a/forgot_password.php
+++ b/forgot_password.php
@@ -3,5 +3,6 @@ require 'config.php';
 
 use NamaHealing\Controllers\ForgotPasswordController;
 
-$controller = new ForgotPasswordController($db);
-$controller->handle();
+// Hiển thị form quên mật khẩu sử dụng controller mới
+$controller = new ForgotPasswordController();
+$controller->forgotForm();

--- a/index.php
+++ b/index.php
@@ -8,7 +8,8 @@ if (getenv('APP_ENV') === 'production') {
     ini_set('display_errors', '0');
 }
 
-define('BASE_PATH', dirname(__DIR__));
+// Đường dẫn gốc của ứng dụng
+define('BASE_PATH', __DIR__);
 
 // Autoload đơn giản (ưu tiên composer nếu có)
 $composer = BASE_PATH . '/vendor/autoload.php';


### PR DESCRIPTION
## Summary
- Correct application base path in router to load vendor autoload properly
- Update legacy forgot password page to use new controller

## Testing
- `php -l index.php`
- `php -l forgot_password.php`
- `composer update` *(fails: CONNECT tunnel failed, response 403)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_68a3e0a142108326bac3a2677ea229d5