### PR TITLE
Handle home route and render error pages

### DIFF
--- a/index.php
+++ b/index.php
@@ -28,6 +28,8 @@ if (file_exists($composer)) {
     });
 }
 
+require_once BASE_PATH . '/helpers/Response.php';
+
 // Nạp env (nếu có vlucas/phpdotenv)
 if (class_exists(\Dotenv\Dotenv::class)) {
     $dotenv = \Dotenv\Dotenv::createImmutable(BASE_PATH);
@@ -43,6 +45,9 @@ use NamaHealing\Helpers\Response;
 // Router đơn giản
 try {
     switch ($uri) {
+        case '/':
+            require BASE_PATH . '/home.php';
+            break;
         case '/forgot-password':
             (new ForgotPasswordController())->forgotForm();
             break;

--- a/views/errors/404.php
+++ b/views/errors/404.php
@@ -1,0 +1,8 @@
+<?php $pageTitle = '404 - Not Found'; include 'header.php'; ?>
+<main class="min-h-[60vh] flex flex-col items-center justify-center text-center">
+  <h1 class="text-4xl font-bold mb-4">404</h1>
+  <p class="mb-6">Page not found.</p>
+  <a href="/" class="text-[#285F57] hover:underline">Return home</a>
+</main>
+<?php include 'footer.php'; ?>
+

--- a/views/errors/500.php
+++ b/views/errors/500.php
@@ -1,0 +1,8 @@
+<?php $pageTitle = '500 - Server Error'; include 'header.php'; ?>
+<main class="min-h-[60vh] flex flex-col items-center justify-center text-center">
+  <h1 class="text-4xl font-bold mb-4">500</h1>
+  <p class="mb-6">An unexpected error occurred.</p>
+  <a href="/" class="text-[#285F57] hover:underline">Return home</a>
+</main>
+<?php include 'footer.php'; ?>
+


### PR DESCRIPTION
## Summary
- Route `/` to the existing `home.php` script.
- Load a Response helper and provide dedicated 404 and 500 view templates.

## Testing
- `php -l index.php`
- `php -l views/errors/404.php`
- `php -l views/errors/500.php`
- `curl -i http://localhost:8000/` *(fails: Kết nối DB lỗi: SQLSTATE[HY000] [2002] No such file or directory)*
- `curl -i http://localhost:8000/unknown`

------
https://chatgpt.com/codex/tasks/task_b_68a3e409895c83268d6f44da2a6c2c76