### PR TITLE
Handle CSRF token errors when registering

### DIFF
--- a/config.php
+++ b/config.php
@@ -44,11 +44,23 @@ try {
 
 // Khởi động session (nếu chưa có)
 if (session_status() === PHP_SESSION_NONE) {
+    $domain = $_SERVER['HTTP_HOST'] ?? '';
+    if (strpos($domain, ':') !== false) {
+        $domain = explode(':', $domain)[0];
+    }
+    if ($domain && $domain !== 'localhost' && !filter_var($domain, FILTER_VALIDATE_IP)) {
+        $domain = '.' . preg_replace('/^www\./', '', $domain);
+    } else {
+        $domain = '';
+    }
+
     session_set_cookie_params([
         'lifetime' => 0,
         'path'     => '/',
+        'domain'   => $domain,
         'httponly' => true,
-        'samesite' => 'Lax'
+        'samesite' => 'Lax',
+        'secure'   => !empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off',
     ]);
     session_start();
 }


### PR DESCRIPTION
## Summary
- ensure session cookies include proper domain and secure flags so CSRF tokens persist across subdomains

## Testing
- `composer install` *(failed: Required package "phpmailer/phpmailer" is not present in the lock file)*
- `./vendor/bin/phpunit --testdox` *(failed: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_68a43639d58c83269dd061ded8b54de4