### PR TITLE
fix: call global helpers in registration controllers

### DIFF
--- a/controllers/RegisterController.php
+++ b/controllers/RegisterController.php
@@ -18,17 +18,17 @@ class RegisterController {
         }
         $err = "";
         if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-            csrf_check($_POST['csrf_token'] ?? null);
+            \csrf_check($_POST['csrf_token'] ?? null);
             $name  = trim($_POST['full_name'] ?? '');
             $email = trim($_POST['email'] ?? '');
             $phone = trim($_POST['phone'] ?? '');
             $pass  = $_POST['password'] ?? '';
             if (!$name || !$email || !$phone || !$pass) {
-                $err = __('err_required_fields');
+                $err = \__('err_required_fields');
             } else {
                 $model = new UserModel($this->db);
                 if ($model->findByIdentifier($email) || $model->findByIdentifier($phone)) {
-                    $err = __('err_email_exists');
+                    $err = \__('err_email_exists');
                 } else {
                     $model->createStudent($name, $email, $phone, $pass);
                     header('Location: admin.php');

--- a/controllers/SelfRegisterController.php
+++ b/controllers/SelfRegisterController.php
@@ -14,17 +14,17 @@ class SelfRegisterController {
     public function handle(): void {
         $err = "";
         if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-            csrf_check($_POST['csrf_token'] ?? null);
+            \csrf_check($_POST['csrf_token'] ?? null);
             $name  = trim($_POST['full_name'] ?? '');
             $email = trim($_POST['email'] ?? '');
             $phone = trim($_POST['phone'] ?? '');
             $pass  = $_POST['password'] ?? '';
             if (!$name || !$email || !$phone || !$pass) {
-                $err = __('err_required_fields');
+                $err = \__('err_required_fields');
             } else {
                 $model = new UserModel($this->db);
                 if ($model->findByIdentifier($phone) || $model->findByIdentifier($email)) {
-                    $err = __('err_email_exists');
+                    $err = \__('err_email_exists');
                 } else {
                     $model->createStudent($name, $email, $phone, $pass);
                     header('Location: welcome.php');


### PR DESCRIPTION
## Summary
- use fully qualified names for csrf_check and translation helper to avoid namespace resolution errors

## Testing
- `php -l controllers/SelfRegisterController.php`
- `php -l controllers/RegisterController.php`


------
https://chatgpt.com/codex/tasks/task_b_68a438ff979c8326a3a9cd40e1f5739c