### PR TITLE
Update user schema and registration flow

### DIFF
--- a/controllers/RegisterController.php
+++ b/controllers/RegisterController.php
@@ -19,18 +19,18 @@ class RegisterController {
         $err = "";
         if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             \csrf_check($_POST['csrf_token'] ?? null);
-            $name  = trim($_POST['full_name'] ?? '');
-            $email = trim($_POST['email'] ?? '');
-            $phone = trim($_POST['phone'] ?? '');
-            $pass  = $_POST['password'] ?? '';
-            if (!$name || !$email || !$phone || !$pass) {
+            $fullName = trim($_POST['full_name'] ?? '');
+            $email    = trim($_POST['email'] ?? '');
+            $phone    = trim($_POST['phone'] ?? '');
+            $pass     = $_POST['password'] ?? '';
+            if (!$fullName || !$email || !$phone || !$pass) {
                 $err = \__('err_required_fields');
             } else {
                 $model = new UserModel($this->db);
                 if ($model->findByIdentifier($email) || $model->findByIdentifier($phone)) {
                     $err = \__('err_email_exists');
                 } else {
-                    $model->createStudent($name, $email, $phone, $pass);
+                    $model->createStudent($fullName, $email, $phone, $pass);
                     header('Location: admin.php');
                     exit;
                 }

--- a/controllers/SelfRegisterController.php
+++ b/controllers/SelfRegisterController.php
@@ -15,18 +15,18 @@ class SelfRegisterController {
         $err = "";
         if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             \csrf_check($_POST['csrf_token'] ?? null);
-            $name  = trim($_POST['full_name'] ?? '');
-            $email = trim($_POST['email'] ?? '');
-            $phone = trim($_POST['phone'] ?? '');
-            $pass  = $_POST['password'] ?? '';
-            if (!$name || !$email || !$phone || !$pass) {
+            $fullName = trim($_POST['full_name'] ?? '');
+            $email    = trim($_POST['email'] ?? '');
+            $phone    = trim($_POST['phone'] ?? '');
+            $pass     = $_POST['password'] ?? '';
+            if (!$fullName || !$email || !$phone || !$pass) {
                 $err = \__('err_required_fields');
             } else {
                 $model = new UserModel($this->db);
                 if ($model->findByIdentifier($phone) || $model->findByIdentifier($email)) {
                     $err = \__('err_email_exists');
                 } else {
-                    $model->createStudent($name, $email, $phone, $pass);
+                    $model->createStudent($fullName, $email, $phone, $pass);
                     header('Location: welcome.php');
                     exit;
                 }

--- a/data/sql/patch_users_table.sql
+++ b/data/sql/patch_users_table.sql
@@ -1,0 +1,7 @@
+-- Update users table to new schema
+ALTER TABLE users
+    CHANGE COLUMN name full_name VARCHAR(255) NOT NULL,
+    CHANGE COLUMN pass password VARCHAR(255) NOT NULL,
+    ADD COLUMN phone VARCHAR(255) DEFAULT NULL,
+    ADD COLUMN role VARCHAR(50) NOT NULL DEFAULT 'student',
+    ADD COLUMN remaining INT NOT NULL DEFAULT 0;

--- a/models/UserModel.php
+++ b/models/UserModel.php
@@ -39,17 +39,17 @@ class UserModel {
      * application. Passwords are hashed and the account is created with the
      * default role of `student` and no remaining sessions.
      */
-    public function createStudent(string $name, string $email, string $phone, string $password): int {
+    public function createStudent(string $fullName, string $email, string $phone, string $password): int {
         $hash = password_hash($password, PASSWORD_DEFAULT);
         $stmt = $this->pdo->prepare(
             "INSERT INTO users (full_name, email, phone, password, role, remaining, created_at) " .
-            "VALUES (:name, :email, :phone, :pass, 'student', 0, NOW())"
+            "VALUES (:full_name, :email, :phone, :pass, 'student', 0, NOW())"
         );
         $stmt->execute([
-            ':name'  => $name,
-            ':email' => $email,
-            ':phone' => $phone,
-            ':pass'  => $hash,
+            ':full_name' => $fullName,
+            ':email'     => $email,
+            ':phone'     => $phone,
+            ':pass'      => $hash,
         ]);
         return (int)$this->pdo->lastInsertId();
     }


### PR DESCRIPTION
## Summary
- rename createStudent parameter to `$fullName` and reference new columns
- update registration controllers to use `full_name`
- add SQL patch altering `users` table with `full_name`, `password`, `phone`, `role`, and `remaining`

## Testing
- ⚠️ `vendor/bin/phpunit tests` *(phpunit: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a43ec864e08326af81b4914ee5fa9d