### PR TITLE
Enable PDO exceptions for better debugging

### DIFF
--- a/config.php
+++ b/config.php
@@ -38,6 +38,7 @@ $dbPass = $_ENV['DB_PASS'] ?? '';
 try {
     $dsn = "mysql:host={$dbHost};dbname={$dbName};charset=utf8";
     $db = new PDO($dsn, $dbUser, $dbPass);
+    $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 } catch (PDOException $e) {
     die("Kết nối DB lỗi: " . $e->getMessage());
 }


### PR DESCRIPTION
## Summary
- Enable exception throwing on PDO connections for detailed database error reporting.

## Testing
- `php -l config.php`
- `php -r '$_SERVER["REQUEST_METHOD"]="POST"; $_POST=["csrf_token"=>"dummy","full_name"=>"Test User","email"=>"test@example.com","phone"=>"123456","password"=>"pass"]; include "register.php";'` *(fails: No such file or directory for DB)*
- `phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a43ed2ef2c8326a4836b7a611c5f81