### PR TITLE
Fix login redirects by removing extraneous output

### DIFF
--- a/config.php
+++ b/config.php
@@ -86,4 +86,3 @@ if (defined('REQUIRE_LOGIN') && !isset($_SESSION['uid'])) {
     header('Location: login.php');
     exit;
 }
-?>


### PR DESCRIPTION
## Summary
- Remove closing PHP tag from config.php to prevent unwanted output before headers, ensuring login redirect works.

## Testing
- `vendor/bin/phpunit --testdox` *(fails: No such file or directory)*
- `apt-get update` *(fails: repository not signed 403)*

------
https://chatgpt.com/codex/tasks/task_b_68a45767ad3083268651d5b520605c6c