### PR TITLE
[NamaHealing] Document PHP 8 requirement and refine login

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # NamaHealing Contributor Guide
 
 ## Dev Environment Tips
+- Requires PHP 8.0 or higher.
 - Run `composer install` to pull in PHP dependencies like `vlucas/phpdotenv`.
 - Create a `.env` file and add `OPENAI_API_KEY=sk-proj-...` so `config.php` can load it.
 - Launch a local server from the project root with `php -S localhost:8000` to preview pages.

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
         }
     ],
     "require": {
+        "php": ">=8.0",
         "vlucas/phpdotenv": "^5.6",
         "phpmailer/phpmailer": "^6.9"
     }

--- a/config.php
+++ b/config.php
@@ -1,4 +1,8 @@
 <?php
+if (PHP_VERSION_ID < 80000) {
+    http_response_code(500);
+    exit('Requires PHP 8.0 or higher');
+}
 // Nạp Composer autoloader (nếu có)
 if (file_exists(__DIR__ . '/vendor/autoload.php')) {
     require_once __DIR__ . '/vendor/autoload.php';

--- a/controllers/LoginController.php
+++ b/controllers/LoginController.php
@@ -15,7 +15,7 @@ class LoginController {
         $err = "";
         if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             csrf_check($_POST['csrf_token'] ?? null);
-            $identifier = $_POST['identifier'] ?? '';
+            $identifier = trim($_POST['identifier'] ?? '');
             // Identifier can be email or phone
             $pass  = $_POST['password'] ?? '';
             $model = new UserModel($this->db);


### PR DESCRIPTION
## Summary
- Declare PHP >=8.0 requirement in `composer.json` and runtime check in `config.php`
- Note PHP 8+ in contributor guide
- Trim login identifier to avoid hidden whitespace login failures

## Testing
- `composer install` *(fails: Required package "phpmailer/phpmailer" is not present in the lock file)*
- `composer update` *(fails: curl error 56 while downloading https://repo.packagist.org/packages.json: CONNECT tunnel failed, response 403)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_68a465086fa483268074d9073c774de2