### PR TITLE
Fix login require path and ordering

### DIFF
--- a/login.php
+++ b/login.php
@@ -1,7 +1,9 @@
 <?php
-require 'config.php';
 
 use NamaHealing\Controllers\LoginController;
 
+require __DIR__ . '/config.php';
+
 $controller = new LoginController($db);
 $controller->handle();
+


### PR DESCRIPTION
## Summary
- ensure LoginController import occurs before config
- use explicit path for config include

## Testing
- `php -l login.php`
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_68a5319cfbf8832685a05a53ab8fb8e0