### PR TITLE
Adjust login persistence and disable class time gate

### DIFF
--- a/join.php
+++ b/join.php
@@ -29,7 +29,8 @@ $uid = $_SESSION['uid'];
 $session = ($_POST['session'] ?? 'morning');
 if (!in_array($session, ['morning', 'evening'])) $session = 'morning';
 
-// Kiểm tra khung giờ cho phép vào lớp
+// Tạm thời bỏ kiểm tra khung giờ để test Zoom
+/*
 $now = date('H:i');
 $allowed = false;
 if ($session === 'morning') {
@@ -43,6 +44,7 @@ if (!$allowed) {
     echo "<!DOCTYPE html><html><head>{$gtm_head}<meta charset='utf-8'><title>{$title}</title></head><body>{$gtm_body}<p>" . __('not_class_time') . "</p></body></html>";
     exit;
 }
+*/
 
 // Kiểm tra số buổi còn lại
 $stmt = $db->prepare("SELECT remaining FROM users WHERE id=?");

--- a/login.php
+++ b/login.php
@@ -1,6 +1,23 @@
 <?php
 require 'config.php';
 
+// Nếu đã đăng nhập, chuyển thẳng tới giao diện tương ứng
+if (isset($_SESSION['uid'])) {
+    if (($_SESSION['role'] ?? '') === 'admin') {
+        header('Location: admin.php');
+        exit;
+    } elseif (($_SESSION['role'] ?? '') === 'teacher') {
+        header('Location: teacher_dashboard.php');
+        exit;
+    } else {
+        $stmt = $db->prepare("SELECT remaining FROM users WHERE id=?");
+        $stmt->execute([$_SESSION['uid']]);
+        $remaining = (int)$stmt->fetchColumn();
+        header('Location: ' . ($remaining > 0 ? 'dashboard.php' : 'welcome.php'));
+        exit;
+    }
+}
+
 // Xử lý logic đăng nhập
 $err = '';
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {

--- a/logout.php
+++ b/logout.php
@@ -15,6 +15,6 @@ if (ini_get("session.use_cookies")) {
     );
 }
 
-// Quay về trang đăng nhập / trang chủ
-header('Location: index.php');
+// Quay về trang đăng nhập
+header('Location: login.php');
 exit;


### PR DESCRIPTION
## Summary
- Temporarily comment out class time restriction when joining Zoom sessions for easier link testing
- Redirect users from login page if already authenticated and send logout to login page

## Testing
- `php -l join.php login.php logout.php`
- `vendor/bin/phpunit` *(fails: vendor/bin/phpunit: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_68a675d90fb48326a928f51e29894bc1