### PR TITLE
Adjust join window for class sessions

### DIFF
--- a/join.php
+++ b/join.php
@@ -35,7 +35,7 @@ function should_count_session(string $session): bool {
     } else {
         $start = strtotime('20:45');
     }
-    return ($now >= $start - 15 * 60) && ($now <= $start + 15 * 60);
+    return ($now >= $start - 10 * 60) && ($now <= $start + 45 * 60);
 }
 $shouldCount = should_count_session($session);
 


### PR DESCRIPTION
## Summary
- Only count class attendance from 10 minutes before start time until 45 minutes after.

## Testing
- `phpunit tests` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `composer require --dev phpunit/phpunit` *(fails: CONNECT tunnel failed, 403)*

------
https://chatgpt.com/codex/tasks/task_b_68a691d58ec483269def8c8251e5a5d2