### PR TITLE
Replace Google Tag Manager ID

### DIFF
--- a/header.php
+++ b/header.php
@@ -9,7 +9,7 @@ require_once __DIR__ . '/i18n.php';
   new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
   j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-  })(window,document,'script','dataLayer','GTM-PNFMJD34');</script>
+  })(window,document,'script','dataLayer','GTM-MZ695946');</script>
   <!-- End Google Tag Manager -->
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -49,7 +49,7 @@ require_once __DIR__ . '/i18n.php';
 </head>
 <body class="bg-[#f9fafb] text-[#374151] pt-20 sm:pt-16">
   <!-- Google Tag Manager (noscript) -->
-  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-PNFMJD34"
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MZ695946"
   height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <!-- End Google Tag Manager (noscript) -->
   <!-- Header bar -->

--- a/home.php
+++ b/home.php
@@ -18,7 +18,7 @@ $currentUrl = (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on' ? 'https' 
   new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
   j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-  })(window,document,'script','dataLayer','GTM-PNFMJD34');</script>
+  })(window,document,'script','dataLayer','GTM-MZ695946');</script>
   <!-- End Google Tag Manager -->
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -148,7 +148,7 @@ $currentUrl = (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on' ? 'https' 
 
 <body class="overflow-x-hidden">
   <!-- Google Tag Manager (noscript) -->
-  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-PNFMJD34"
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MZ695946"
   height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
   <!-- End Google Tag Manager (noscript) -->
   <!-- Thanh header trong suốt hoàn toàn -->

--- a/join.php
+++ b/join.php
@@ -4,13 +4,13 @@ require 'config.php';
 
 $gtm_head = <<<'HTML'
 <!-- Google Tag Manager -->
-<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-PNFMJD34');</script>
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-MZ695946');</script>
 <!-- End Google Tag Manager -->
 HTML;
 
 $gtm_body = <<<'HTML'
 <!-- Google Tag Manager (noscript) -->
-<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-PNFMJD34" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MZ695946" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->
 HTML;
 


### PR DESCRIPTION
## Summary
- update Google Tag Manager script ID to `GTM-MZ695946`

## Testing
- `php -l home.php header.php join.php`
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `apt-get update` *(fails: repository not signed)*
- `curl -L -o phpunit.phar https://phar.phpunit.de/phpunit-11.phar` *(fails: CONNECT tunnel failed 403)*

------
https://chatgpt.com/codex/tasks/task_b_68ac37e6b6fc8326bf8a5fab647e8759